### PR TITLE
docs: Compare Jenni AI in feature matrix

### DIFF
--- a/.changeset/issue-20-jenni-comparison.md
+++ b/.changeset/issue-20-jenni-comparison.md
@@ -1,0 +1,5 @@
+---
+'my-package': patch
+---
+
+Expand the feature comparison docs with a Jenni AI-focused academic-writing assistant matrix.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
-# Updated: 2026-05-12T10:52:04.133Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
+# Updated: 2026-05-12T10:52:04.133Z

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -46,6 +46,7 @@ https://idir\.uta\.edu
 https://allenai\.org
 https://www\.let\.rug\.nl
 https://query\.wikidata\.org
+https://yago-knowledge\.org
 
 # GitHub "new issue" page requires a logged-in session — link is intentional
 # but the unauthenticated bot probe is rejected.

--- a/docs/COMPARISON-FEATURES.md
+++ b/docs/COMPARISON-FEATURES.md
@@ -1,8 +1,10 @@
 # Feature comparison: meta-expression vs. similar projects
 
-> Last checked: 2026-05-11.
+> Last checked: 2026-05-12.
 > Companion document: [`COMPARISON-CONCEPTS.md`](./COMPARISON-CONCEPTS.md).
 > Source case study: [`docs/case-studies/issue-26/`](./case-studies/issue-26/).
+> Issue #20 extension:
+> [`docs/case-studies/issue-20/`](./case-studies/issue-20/).
 
 This matrix turns the seven concept clusters from
 [`COMPARISON-CONCEPTS.md`](./COMPARISON-CONCEPTS.md) into a per-feature
@@ -76,7 +78,42 @@ log [`docs/case-studies/issue-26/ONLINE-RESEARCH.md`](./case-studies/issue-26/ON
 | F16 Issue-report URL prefilled         | —                         | —                       | —                     | —                         | —                     | —                         | —                                         | —                       | —                                      | —                       | —                | —                      | —                        |
 | F17 Rust + doublets core               | —                         | —                       | —                     | —                         | —                     | —                         | —                                         | —                       | —                                      | —                       | ✓ (Rust drivers) | ≈                      | ✓ (doublets-rs)          |
 
-## 3. How to read F8 vs F9
+## 3. Expanded academic-writing assistant matrix
+
+Issue #20 asks for the comparison to include projects from the
+AI-writing / academic-assistant cluster directly, rather than only via
+the representative columns above. This focused lens keeps the
+full-feature rows but narrows the columns to the assistant products most
+likely to be compared with Jenni AI.
+
+| Feature                                | Jenni AI                                    | Elicit                                | Grammarly                         | Consensus.app                   |
+| -------------------------------------- | ------------------------------------------- | ------------------------------------- | --------------------------------- | ------------------------------- |
+| F1 Reusable JS library                 | —                                           | ≈ (REST API with JS examples)         | —                                 | ≈ (API by application)          |
+| F2 CLI                                 | —                                           | ≈ (API examples include CLI/MCP glue) | —                                 | —                               |
+| F3 Microservice                        | —                                           | ✓ (hosted API)                        | —                                 | ✓ (hosted API)                  |
+| F4 Static web prototype                | ✓ (web editor)                              | ✓ (web app)                           | ✓ (web/editor/extensions)         | ✓ (web app)                     |
+| F5 Interpretation pipeline             | ≈ (autocomplete + chat)                     | ≈ (paper chat / reports)              | ≈ (rewrites + Citation Finder)    | ≈ (query-to-papers search)      |
+| F6 Formal levels                       | —                                           | —                                     | —                                 | —                               |
+| F7 Exact arithmetic                    | —                                           | —                                     | —                                 | —                               |
+| F8 Real-world evidence                 | ≈ (citations + source-controlled chat)      | ✓ (paper metadata + excerpts)         | ≈ (citation and source refs)      | ✓ (peer-reviewed citations)     |
+| F9 Correctness + signed confidence     | ≈ (Claim Confidence categories)             | ≈ (relevance / screening signals)     | ≈ (originality / match score)     | ✓ (Consensus Meter)             |
+| F10 Formalize → markdown/Lino/HTML/CST | ≈ (document / BibTeX export, not CST)       | ≈ (PDF/Word/CSV/BIB/RIS exports)      | ≈ (citation formatting/rewrites)  | —                               |
+| F11 Translate via formalized entities  | ≈ (multilingual writing; no entity mapping) | —                                     | —                                 | —                               |
+| F12 /check (fact-check)                | ≈ (Claim Confidence, not public endpoint)   | ≈ (paper-grounded review workflows)   | ≈ (integrity/citation checks)     | ✓ (yes/no literature agreement) |
+| F13 /uniqueness (originality)          | ≈ (source-confidence review only)           | —                                     | ✓ (plagiarism/originality report) | —                               |
+| F14 Preference profiles                | ≈ (source/language toggles)                 | ≈ (protocols, filters, columns)       | ≈ (tone/style goals)              | ≈ (filters + saved libraries)   |
+| F15 Links Notation export              | —                                           | —                                     | —                                 | —                               |
+| F16 Issue-report URL prefilled         | —                                           | —                                     | —                                 | —                               |
+| F17 Rust + doublets core               | —                                           | —                                     | —                                 | —                               |
+
+The focused view shows Jenni AI's closest overlap with meta-expression
+is not deterministic reasoning or Links Notation export; it is the
+writing-assistant side of F4, F8, F9, F12, F13, and F14. Grammarly is
+the stronger direct comparison for originality scoring (F13), while
+Elicit and Consensus.app are stronger comparisons for paper discovery,
+evidence attachment, and literature-level confidence.
+
+## 4. How to read F8 vs F9
 
 The F8 ("evidence") and F9 ("correctness + signed confidence") rows do
 **not** mean the same thing:
@@ -89,7 +126,7 @@ The F8 ("evidence") and F9 ("correctness + signed confidence") rows do
   analog to meta-expression's `signedConfidence`. Wolfram Alpha and Z3
   return a binary verdict only, so they sit at `≈`.
 
-## 4. Notable gaps the matrix reveals
+## 5. Notable gaps the matrix reveals
 
 - **F16 (issue-report URL prefilled)** is unique to meta-expression in
   this survey. No comparable project ships a one-click "report this
@@ -107,8 +144,13 @@ The F8 ("evidence") and F9 ("correctness + signed confidence") rows do
   defining intersection: Wolfram Alpha covers both but charges for the
   API and is closed-source; Wikidata covers F8 but not F7; Z3 and
   Coq/Lean cover F7 but not F8.
+- **Academic-writing assistants** (Jenni AI, Elicit, Grammarly, and
+  Consensus.app) cluster around citations, source review, originality,
+  and literature synthesis. None of them expose meta-expression's
+  prefilled issue-report state, Links Notation export, or Rust/doublets
+  persistence surface.
 
-## 5. How this matrix is maintained
+## 6. How this matrix is maintained
 
 1. When a new feature lands in meta-expression, add a row to §1 and a
    column-by-column assessment in §2.

--- a/docs/case-studies/issue-20/README.md
+++ b/docs/case-studies/issue-20/README.md
@@ -1,0 +1,46 @@
+# Case Study: Issue #20 — compare features with Jenni AI
+
+> Source: <https://github.com/link-assistant/meta-expression/issues/20>
+> Pull request: <https://github.com/link-assistant/meta-expression/pull/34>
+> Last checked: 2026-05-12.
+
+## Problem Statement
+
+Issue #20 asks to expand the existing comparison to cover more projects
+from the comparison set and products like <https://jenni.ai>. The gap was
+specific to the feature matrix: Jenni AI already appeared in
+[`docs/COMPARISON-CONCEPTS.md`](../../COMPARISON-CONCEPTS.md), but
+[`docs/COMPARISON-FEATURES.md`](../../COMPARISON-FEATURES.md) collapsed
+AI-writing assistants into representative columns and did not show a
+direct Jenni AI feature comparison.
+
+## Source Review
+
+| Project       | Sources checked                                                                                                                                | Notes for the matrix                                                                                                                                         |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Jenni AI      | <https://jenni.ai/pricing>, <https://help.jenni.ai/docs/ai-tools/ai-autocomplete/>, <https://help.jenni.ai/docs/research/citation-management/> | Web editor, autocomplete, AI chat, citations, bibliography export, source controls, and claim-confidence reviews. No public CLI, JS library, or Lino export. |
+| Jenni AI      | <https://help.jenni.ai/docs/ai-tools/ai-chat/>, <https://help.jenni.ai/docs/ai-tools/reviews/>                                                 | AI Chat can use current document, library, web, and selected text sources; Reviews include proofread and claim-confidence modes.                             |
+| Elicit        | <https://docs.elicit.com/>, <https://support.elicit.com/en/articles/1418881>, <https://support.elicit.com/en/articles/7927169>                 | API, research reports, Find Papers, Paper Chat, systematic review workflow, screening, extraction, and paper-grounded reports.                               |
+| Elicit        | <https://support.elicit.com/en/articles/1153857>, <https://support.elicit.com/en/articles/553025>                                              | CSV/Excel/BIB/RIS/PDF/Word exports and paper corpus/source notes.                                                                                            |
+| Grammarly     | <https://www.grammarly.com/plans>, <https://www.grammarly.com/plagiarism-checker>, <https://www.grammarly.com/citations>                       | Web/editor assistance, plagiarism/originality report, citation generation, Citation Finder, citation formatting, and writing suggestions.                    |
+| Consensus.app | <https://help.consensus.app/en/articles/9922673-how-consensus-works>, <https://help.consensus.app/en/articles/10069920-the-consensus-meter>    | Peer-reviewed paper search, cited synthesis, Consensus Meter, Ask Paper, filters, and library features.                                                      |
+| Consensus.app | <https://consensus.app/home/api/>, <https://help.consensus.app/en/articles/9922799-how-to-filter-searches-by-paper-details>                    | API access, metadata, relevance scores, advanced filters, and hosted search surface.                                                                         |
+
+## Decision
+
+The fix adds an "Expanded academic-writing assistant matrix" to
+[`docs/COMPARISON-FEATURES.md`](../../COMPARISON-FEATURES.md). It keeps
+the existing public feature IDs F1-F17 and compares Jenni AI, Elicit,
+Grammarly, and Consensus.app directly.
+
+That scope is intentionally narrower than reopening the whole issue #26
+survey. These four products cover the direct Jenni-like comparison space:
+academic drafting, citation support, literature search, source-grounded
+review, originality checking, and confidence/consensus surfaces.
+
+## Verification
+
+The regression test `tests/issue-20.test.js` checks that the feature
+comparison contains the expanded assistant matrix, includes Jenni AI and
+the comparable assistant products, retains key feature rows, and archives
+the Jenni source URLs in this case study.

--- a/tests/issue-20.test.js
+++ b/tests/issue-20.test.js
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, it, expect } from 'test-anywhere';
+
+const FEATURE_COMPARISON_PATH = 'docs/COMPARISON-FEATURES.md';
+const ISSUE_20_CASE_STUDY_PATH = 'docs/case-studies/issue-20/README.md';
+
+describe('issue 20 — Jenni AI comparison expansion', () => {
+  it('adds a focused academic-writing assistant feature lens', () => {
+    const features = readFileSync(FEATURE_COMPARISON_PATH, 'utf8');
+
+    expect(
+      features.includes('Expanded academic-writing assistant matrix')
+    ).toBe(true);
+
+    for (const project of [
+      'Jenni AI',
+      'Elicit',
+      'Grammarly',
+      'Consensus.app',
+    ]) {
+      expect(features.includes(project)).toBe(true);
+    }
+
+    for (const feature of [
+      'F8 Real-world evidence',
+      'F13 /uniqueness (originality)',
+      'F16 Issue-report URL prefilled',
+    ]) {
+      expect(features.includes(feature)).toBe(true);
+    }
+  });
+
+  it('archives the issue-specific research trail', () => {
+    expect(existsSync(ISSUE_20_CASE_STUDY_PATH)).toBe(true);
+
+    const caseStudy = readFileSync(ISSUE_20_CASE_STUDY_PATH, 'utf8');
+    expect(
+      caseStudy.includes(
+        'https://github.com/link-assistant/meta-expression/issues/20'
+      )
+    ).toBe(true);
+    expect(caseStudy.includes('https://jenni.ai/pricing')).toBe(true);
+    expect(
+      caseStudy.includes('https://help.jenni.ai/docs/ai-tools/ai-autocomplete/')
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #20

## What
- Adds an expanded academic-writing assistant matrix to `docs/COMPARISON-FEATURES.md` comparing Jenni AI, Elicit, Grammarly, and Consensus.app across F1-F17.
- Adds `docs/case-studies/issue-20/README.md` with the source trail used for the feature ratings.
- Adds `tests/issue-20.test.js` to keep the Jenni AI comparison and source trail from regressing.
- Adds YAGO to `.lycheeignore` because the official YAGO site remains valid but times out under CI link checking.
- Adds a patch changeset.

## Why
Jenni AI was already listed in the concept comparison, but the feature matrix collapsed AI-writing assistants into representative columns and did not show a direct Jenni-like comparison.

## Testing
- `node --test tests/issue-20.test.js`
- `npm test`
- `bun test`
- `deno test --allow-read`
- `npm run check`
