### PR TITLE
fix: publish as meta-expression package

### DIFF
--- a/.changeset/bounded-beliefs-examples.md
+++ b/.changeset/bounded-beliefs-examples.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Add bounded real-world confidence, local belief evidence, prepared examples, formalization level labels, issue reporting, live Wikimedia evidence resolution, and the initial Rust/Doublets core for the meta-expression prototype.

--- a/.changeset/issue-13-two-metrics.md
+++ b/.changeset/issue-13-two-metrics.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Surface two default metrics on every analysis — `result.correctness` (0..1) and `result.signedConfidence` (-1..1) — and add a top-menu Compare page to put competing claims side-by-side.

--- a/.changeset/issue-15-formalize-section.md
+++ b/.changeset/issue-15-formalize-section.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add a `/formalize` library, CLI, HTTP endpoint, and SPA tab that wikifies free-form text against Wikidata (with WordNet and Fandom as layered sources), surfaces big-context categories (Math, Geography, Star Wars, …), supports repository-level and user overrides, and persists `/formalize` HTTP results to a dual-format on-disk cache. Library reference is auto-generated from JSDoc into `docs/FORMALIZE.md` and validated in CI via `npm run docs:formalize:check`.

--- a/.changeset/issue-16-translate.md
+++ b/.changeset/issue-16-translate.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add a Wikidata-backed translation surface that formalizes source text first,

--- a/.changeset/issue-17-check.md
+++ b/.changeset/issue-17-check.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add `/check` and `/fact-check` statement checking with red-to-green correctness coloring, evidence-situation probability scoring, and configurable Wikimedia/Wikidata defaults.

--- a/.changeset/issue-18-preferences.md
+++ b/.changeset/issue-18-preferences.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add a `/preferences` section with local worldview sliders, conditional religion

--- a/.changeset/issue-20-jenni-comparison.md
+++ b/.changeset/issue-20-jenni-comparison.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Expand the feature comparison docs with a Jenni AI-focused academic-writing assistant matrix.

--- a/.changeset/issue-21-snapshot-cache.md
+++ b/.changeset/issue-21-snapshot-cache.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Issue #21 — perfect context detection in the Formalize pipeline. Adds an HTTP-level snapshot cache (`src/formalize-snapshots.js`) with REPLAY/RECORD/OVERLAY modes, persisting Wikipedia/Wikidata/Wiktionary responses to `tests/fixtures/wikimedia-snapshots/` (URL → SHA-1 keyed JSON plus a human-readable `manifest.lino`). Tests can now formalize "Hawaii", "formalize", and "the" entirely offline. The Formalize page gains a "Load repo sample" picker that runs the pipeline against repository content (README, docs, package.json, issue-21 examples), and the recorder script lives at `examples/record-wikimedia-snapshots.js` so the fixtures can be refreshed idempotently.

--- a/.changeset/issue-23-ui-overhaul.md
+++ b/.changeset/issue-23-ui-overhaul.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 UI/UX overhaul of the static `web/` prototype: readable contrast inside `<details>` payload panels, clean radio fieldsets for Link Target / Sources / Interpretation Display, switchable interpretation display modes (`id` / `name` / `name+meaning` / `meaning` / `replace`), clickable interpretations with the active choice always pinned to the top‑10, language switching (`en`, `ru`) with `navigator.language` detection plus `localStorage` override, theme switching (`auto` / `light` / `dark`) with `prefers-color-scheme` detection plus `localStorage` override, and a mobile-first responsive layout (single column ≤640px, two-column from 640px, full app-shell from 960px).

--- a/.changeset/issue-26-comparison-docs.md
+++ b/.changeset/issue-26-comparison-docs.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add concept and feature comparison docs vs. similar projects, plus an issue-26 case study and a comparable-system fixtures test suite.

--- a/.changeset/issue-27-uniqueness.md
+++ b/.changeset/issue-27-uniqueness.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add a uniqueness checking API, CLI, HTTP route, and web section for finding prior public statements.

--- a/.changeset/issue-29-page-reporting.md
+++ b/.changeset/issue-29-page-reporting.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add page-aware GitHub issue reporting and GitHub Pages version diagnostics.

--- a/.changeset/issue-35-hawaii-translation.md
+++ b/.changeset/issue-35-hawaii-translation.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Fix Hawaii sentence translation by identifying Wikimedia API requests, filtering grammar-fragment n-grams, demoting disambiguation candidates, keeping refined target ids in the phrase trace, and rendering the tested English/Russian copula plus U.S.-state predicate round trip. Add a narrow Rust semantic fixture for the same issue case.

--- a/.changeset/issue-37-translate-reporting.md
+++ b/.changeset/issue-37-translate-reporting.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Fix Translate page issue reports so oversized generated diagnostics are omitted

--- a/.changeset/issue-39-translate-strategies.md
+++ b/.changeset/issue-39-translate-strategies.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Improve Translate output for technical English to Russian text with selectable strategies, contextual glossary fallback, structured question options, and prepared Translate examples.

--- a/.changeset/issue-41-russian-translate.md
+++ b/.changeset/issue-41-russian-translate.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Fix Russian-to-English Translate output by rejecting snippet-only formalization hits, adding lexical fallback handling for short Russian phrases, and exposing the semantic meta-language plus naturalization trace used for translation.

--- a/.changeset/issue-43-translation-quality.md
+++ b/.changeset/issue-43-translation-quality.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add a Wikipedia top-views translation-quality gate. New `assessArticleSet()`, `assessArticleTranslation()`, `selectLanguagePair()`, `summarizeAssessment()`, `extractFirstStatement()`, `tokenCoverage()`, `tokenizeForMatch()`, and `normalizeStatementKey()` helpers route per-article statements through curated skip-list, translation-fixes, direct coverage, and round-trip stability checks. A new `translation-quality` CLI subcommand reads articles/skip-list/fixes JSON, prints a per-status summary, and exits non-zero on failures. The Rust core mirrors the helpers and exposes a `meta_expression_translation_quality_status_code` C ABI for native consumers. Two Translate samples (Artemis II lead, Russian Michael Jackson biographical lead) are added to the web app.

--- a/.changeset/issue-48-translation-coverage.md
+++ b/.changeset/issue-48-translation-coverage.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Link every fallback lexical token through source formalization and target naturalization so Translate reports complete concept coverage for glossary-backed phrases, rule-inserted words, and existing Translate workflows.

--- a/.changeset/issue-50-translate-coverage.md
+++ b/.changeset/issue-50-translate-coverage.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Improve Translate coverage for technical prose, add opt-in local lexical links, and throttle source lookup fan-out to avoid bursting Wikimedia APIs.

--- a/.changeset/issue-52-translate-cache.md
+++ b/.changeset/issue-52-translate-cache.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Reduce Translate Wikimedia request churn, normalize Wiktionary lookups, batch Wikidata entity hydration, and apply Translate question answers to rendered output.

--- a/.changeset/issue-54-formal-ai-hooks.md
+++ b/.changeset/issue-54-formal-ai-hooks.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add Formal AI compatibility hooks for formalization, translation, and naturalization/deformalization aliases, deterministic linguistic CST/AST metadata, and Formal AI prompt translation helpers backed by the pinned upstream test corpus. Also enforce the 1500-line architecture limit for tracked Rust, JavaScript, and Markdown files, with case-study research artifacts excluded.

--- a/.changeset/issue-56-translate-diagnostics.md
+++ b/.changeset/issue-56-translate-diagnostics.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Fix Translate handling for slash-separated fallback terms, add source-backed Wiktionary lexical translation, and add source-priority and debug-log controls for reproducing translation issues.

--- a/.changeset/issue-60-package-identity.md
+++ b/.changeset/issue-60-package-identity.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': patch
+---
+
+Fix the package identity so the documented meta-expression library and CLI are publishable under the project name.

--- a/.changeset/issue-9-vision.md
+++ b/.changeset/issue-9-vision.md
@@ -1,5 +1,5 @@
 ---
-'my-package': minor
+'meta-expression': minor
 ---
 
 Add opposite/negation examples, alternatives, dependencies, definitions,

--- a/.changeset/moon-orbit-chain.md
+++ b/.changeset/moon-orbit-chain.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Support Moon/Sun orbit reasoning through Wikidata parent-body chains and expose Q/P reasoning links in reports and the web prototype.

--- a/.changeset/static-pages-independent-release.md
+++ b/.changeset/static-pages-independent-release.md
@@ -1,5 +1,5 @@
 ---
-'my-package': patch
+'meta-expression': patch
 ---
 
 Publish the static web prototype to GitHub Pages independently from npm package publishing.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-25T19:10:31.966Z for PR creation at branch issue-60-b3b07b32a4f2 for issue https://github.com/link-assistant/meta-expression/issues/60

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -46,6 +46,7 @@ https://lean-lang\.org
 https://idir\.uta\.edu
 https://allenai\.org
 https://www\.let\.rug\.nl
+https://babelnet\.org
 https://query\.wikidata\.org
 https://yago-knowledge\.org
 https://www\.dbpedia\.org

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to js-ai-driven-development-pipeline-template
+# Contributing to meta-expression
 
 ## Development Workflow
 

--- a/experiments/test-changeset-scripts.mjs
+++ b/experiments/test-changeset-scripts.mjs
@@ -150,7 +150,7 @@ function cleanupTestEnvironment() {
 
 function createChangeset(filename, type, description) {
   const content = `---
-'my-package': ${type}
+'meta-expression': ${type}
 ---
 
 ${description}

--- a/experiments/test-check-release-needed.mjs
+++ b/experiments/test-check-release-needed.mjs
@@ -79,7 +79,7 @@ console.log('Test 1: With changesets present');
 }
 
 console.log(
-  '\nTest 2: No changesets, package "my-package" not on npm (self-healing)'
+  '\nTest 2: No changesets, package "meta-expression" not on npm (self-healing)'
 );
 {
   const result = runScript({ HAS_CHANGESETS: 'false' });

--- a/experiments/test-failure-detection.mjs
+++ b/experiments/test-failure-detection.mjs
@@ -78,7 +78,7 @@ const testCases = [
   },
   {
     name: 'Error occurred while publishing',
-    output: `🦋  error an error occurred while publishing my-package: Something went wrong`,
+    output: `🦋  error an error occurred while publishing meta-expression: Something went wrong`,
     shouldFail: true,
   },
   {

--- a/js/tests/unit/package-identity.test.js
+++ b/js/tests/unit/package-identity.test.js
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'test-anywhere';
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function activeChangesetFiles() {
+  return readdirSync('.changeset')
+    .filter((file) => file.endsWith('.md') && file !== 'README.md')
+    .map((file) => join('.changeset', file));
+}
+
+describe('package identity', () => {
+  it('publishes the documented meta-expression package identity', () => {
+    const packageJson = readJson('package.json');
+    const packageLock = readJson('package-lock.json');
+
+    expect(packageJson.name).toBe('meta-expression');
+    expect(packageJson.description.includes('meta-expression')).toBe(true);
+    expect(packageJson.repository.url).toBe(
+      'git+https://github.com/link-assistant/meta-expression.git'
+    );
+    expect(packageJson.bugs.url).toBe(
+      'https://github.com/link-assistant/meta-expression/issues'
+    );
+    expect(packageJson.homepage).toBe(
+      'https://github.com/link-assistant/meta-expression#readme'
+    );
+    expect(packageLock.name).toBe(packageJson.name);
+    expect(packageLock.packages[''].name).toBe(packageJson.name);
+  });
+
+  it('keeps project docs aligned with the published package name', () => {
+    const contributing = readFileSync('docs/CONTRIBUTING.md', 'utf8');
+    const formalizeDocs = readFileSync('docs/FORMALIZE.md', 'utf8');
+    const formalizeGenerator = readFileSync(
+      'scripts/generate-formalize-docs.mjs',
+      'utf8'
+    );
+
+    expect(contributing.startsWith('# Contributing to meta-expression')).toBe(
+      true
+    );
+    expect(formalizeDocs.includes("from 'meta-expression'")).toBe(true);
+    expect(formalizeGenerator.includes("from 'meta-expression'")).toBe(true);
+  });
+
+  it('targets meta-expression in active changesets and release tooling', () => {
+    const changesets = activeChangesetFiles()
+      .map((file) => readFileSync(file, 'utf8'))
+      .join('\n');
+    const releaseScripts = [
+      'scripts/create-manual-changeset.mjs',
+      'scripts/format-release-notes.mjs',
+      'scripts/merge-changesets.mjs',
+      'scripts/publish-to-npm.mjs',
+      'scripts/validate-changeset.mjs',
+    ]
+      .map((file) => readFileSync(file, 'utf8'))
+      .join('\n');
+
+    expect(changesets.includes("'meta-expression':")).toBe(true);
+    expect(changesets.includes('my-package')).toBe(false);
+    expect(releaseScripts.includes('my-package')).toBe(false);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-package",
+  "name": "meta-expression",
   "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-package",
+      "name": "meta-expression",
       "version": "0.9.0",
       "license": "Unlicense",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "my-package",
+  "name": "meta-expression",
   "version": "0.9.0",
-  "description": "A JavaScript/TypeScript package template for AI-driven development",
+  "description": "meta-expression tooling for formalizing text into linked expressions",
   "type": "module",
   "main": "js/src/index.js",
   "types": "js/src/index.d.ts",
@@ -39,17 +39,21 @@
     "changeset:status": "changeset status --since=origin/main"
   },
   "keywords": [
-    "template",
-    "javascript",
-    "typescript",
-    "ai-driven"
+    "meta-expression",
+    "formalization",
+    "links-notation",
+    "translation"
   ],
   "author": "",
   "license": "Unlicense",
   "repository": {
     "type": "git",
-    "url": "https://github.com/link-foundation/js-ai-driven-development-pipeline-template"
+    "url": "git+https://github.com/link-assistant/meta-expression.git"
   },
+  "bugs": {
+    "url": "https://github.com/link-assistant/meta-expression/issues"
+  },
+  "homepage": "https://github.com/link-assistant/meta-expression#readme",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/scripts/create-manual-changeset.mjs
+++ b/scripts/create-manual-changeset.mjs
@@ -4,7 +4,7 @@
  * Create a changeset file for manual releases
  * Usage: node scripts/create-manual-changeset.mjs --bump-type <major|minor|patch> [--description <description>]
  *
- * IMPORTANT: Update the PACKAGE_NAME constant below to match your package.json
+ * Keep the PACKAGE_NAME constant below aligned with package.json.
  *
  * Uses link-foundation libraries:
  * - use-m: Dynamic package loading without package.json dependencies
@@ -15,8 +15,7 @@
 import { writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 
-// TODO: Update this to match your package name in package.json
-const PACKAGE_NAME = 'my-package';
+const PACKAGE_NAME = 'meta-expression';
 
 // Load use-m dynamically
 const { use } = eval(

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -7,7 +7,7 @@
  * - Add shields.io NPM version badge
  * - Format nicely with proper markdown
  *
- * IMPORTANT: Update the PACKAGE_NAME constant below to match your package.json
+ * Keep the PACKAGE_NAME constant below aligned with package.json.
  *
  * PR Detection Logic:
  * 1. Extract commit hash from changelog entry (if present)
@@ -23,8 +23,7 @@
  * Note: Uses --release-version instead of --version to avoid conflict with yargs' built-in --version flag.
  */
 
-// TODO: Update this to match your package name in package.json
-const PACKAGE_NAME = 'my-package';
+const PACKAGE_NAME = 'meta-expression';
 
 // Load use-m dynamically
 const { use } = eval(

--- a/scripts/merge-changesets.mjs
+++ b/scripts/merge-changesets.mjs
@@ -13,7 +13,7 @@
  * This script is run before `changeset version` to ensure a clean release
  * even when multiple PRs have merged before a release cycle.
  *
- * IMPORTANT: Update the package name below to match your package.json
+ * Keep the package name below aligned with package.json.
  */
 
 import {
@@ -25,8 +25,7 @@ import {
 } from 'fs';
 import { join } from 'path';
 
-// TODO: Update this to match your package name in package.json
-const PACKAGE_NAME = 'my-package';
+const PACKAGE_NAME = 'meta-expression';
 const CHANGESET_DIR = '.changeset';
 
 // Version bump type priority (higher number = higher priority)

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -5,7 +5,7 @@
  * Usage: node scripts/publish-to-npm.mjs [--should-pull] [--js-root <path>]
  *   should_pull: Optional flag to pull latest changes before publishing (for release job)
  *
- * IMPORTANT: Update the PACKAGE_NAME constant below to match your package.json
+ * Keep the PACKAGE_NAME constant below aligned with package.json.
  *
  * Configuration:
  * - CLI: --js-root <path> to explicitly set JavaScript root
@@ -31,8 +31,7 @@ import {
   parseJsRootConfig,
 } from './js-paths.mjs';
 
-// TODO: Update this to match your package name in package.json
-const PACKAGE_NAME = 'my-package';
+const PACKAGE_NAME = 'meta-expression';
 
 // Load use-m dynamically
 const { use } = eval(

--- a/scripts/validate-changeset.mjs
+++ b/scripts/validate-changeset.mjs
@@ -9,15 +9,14 @@
  * - Validates that the PR adds exactly one changeset with proper format
  * - Falls back to checking all changesets for local development
  *
- * IMPORTANT: Update the package name below to match your package.json
+ * Keep the package name below aligned with package.json.
  */
 
 import { execSync } from 'child_process';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 
-// TODO: Update this to match your package name in package.json
-const PACKAGE_NAME = 'my-package';
+const PACKAGE_NAME = 'meta-expression';
 const CHANGESET_DIR = '.changeset';
 
 /**


### PR DESCRIPTION
## What

- Rename the JavaScript package identity from `my-package` to `meta-expression`, including package-lock metadata, npm repository metadata, bugs, homepage, and keywords.
- Retitle the contributing guide and add a package identity unit test covering metadata, docs import alignment, changesets, and release tooling.
- Update pending changesets and release helper scripts so the next release targets `meta-expression`, then add the issue-specific changeset.
- Add `babelnet.org` to `.lycheeignore` after fresh CI showed a 403 bot-protection false positive in the existing comparison docs.

## Why

Fixes #60. This resolves the template placeholder identity so the documented `import { ... } from 'meta-expression'` package name matches the publishable npm package.

## Testing

- `node --test js/tests/unit/package-identity.test.js`
- `npm publish --dry-run` → `filename: meta-expression-0.9.0.tgz`, `+ meta-expression@0.9.0`
- `npm run check`
- `npm test`
- `bun test --timeout 30000`
- `deno test -A`
- `GITHUB_BASE_REF=main GITHUB_BASE_SHA=$(git rev-parse origin/main) GITHUB_HEAD_SHA=$(git rev-parse HEAD) node scripts/validate-changeset.mjs`
- `GITHUB_BASE_REF=main GITHUB_HEAD_REF=issue-60-b3b07b32a4f2 node scripts/check-version.mjs`
- `npm view meta-expression name version` returns npm 404 from this environment, so the unscoped package is not currently visible on the registry.
- GitHub Actions on `2334632`: Broken Link Checker, JS Checks and release, and Rust Checks all passed.
