### PR TITLE
Adopt official Links Notation parser and lino-arguments CLI

### DIFF
--- a/.changeset/issue-62-official-parsers.md
+++ b/.changeset/issue-62-official-parsers.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': minor
+---
+
+Adopt the official links-notation parser behind the existing Lino API and load CLI defaults/profiles through lino-arguments.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-25T19:10:31.966Z for PR creation at branch issue-60-b3b07b32a4f2 for issue https://github.com/link-assistant/meta-expression/issues/60
+# Updated: 2026-05-25T20:24:10.008Z

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -2,9 +2,11 @@
 
 import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
+import { makeConfig } from 'lino-arguments';
 import {
   analyzeStatement,
   analyzeStatementWithLiveEvidence,
+  parsePreferenceProfile,
   serializeLinksNotation,
 } from './index.js';
 import { formalizeTextWith, FORMALIZE_LINK_TARGETS } from './formalize.js';
@@ -15,80 +17,84 @@ import { parseSourceSpec } from './formalize-sources.js';
 import { loadRepoOverrides, loadUserOverrides } from './formalize-overrides.js';
 import { assessArticleSet } from './translation-quality.js';
 
+const cliArgvPrefix = ['node', 'meta-expression'];
+
 export function parseCliArguments(args) {
-  const options = {
-    command: 'analyze',
-    format: 'json',
-    inputParts: [],
-    evidenceScoring: {},
-  };
+  const options = createCliOptions(loadCliConfiguration(args));
   let index = 0;
+  let commandSlotOpen = true;
+  const nextValue = (fallback = '') => args[++index] ?? fallback;
   const optionHandlers = {
-    '--input': () => options.inputParts.push(args[++index] ?? ''),
-    '-i': () => options.inputParts.push(args[++index] ?? ''),
+    '--input': () => appendInputPart(options, nextValue()),
+    '-i': () => appendInputPart(options, nextValue()),
     '--format': () => {
-      options.format = args[++index] ?? 'json';
+      options.format = nextValue('json');
     },
     '-f': () => {
-      options.format = args[++index] ?? 'json';
+      options.format = nextValue('json');
     },
     '--select': () => {
-      options.interpretationIndex = Number(args[++index] ?? 0);
+      options.interpretationIndex = Number(nextValue(0));
     },
     '-s': () => {
-      options.interpretationIndex = Number(args[++index] ?? 0);
+      options.interpretationIndex = Number(nextValue(0));
     },
     '--live': () => {
       options.live = true;
     },
     '--target': () => {
-      options.target = args[++index] ?? 'wikipedia';
+      options.target = nextValue('wikipedia');
     },
     '--to': () => {
-      options.targetLanguage = args[++index] ?? 'ru';
+      options.targetLanguage = nextValue('ru');
     },
     '--translation-strategy': () => {
-      options.translationStrategy = args[++index] ?? '';
+      options.translationStrategy = nextValue();
     },
     '--target-language': () => {
-      options.targetLanguage = args[++index] ?? 'ru';
+      options.targetLanguage = nextValue('ru');
     },
     '--from': () => {
-      options.sourceLanguage = args[++index] ?? 'en';
+      options.sourceLanguage = nextValue('en');
     },
     '--source-language': () => {
-      options.sourceLanguage = args[++index] ?? 'en';
+      options.sourceLanguage = nextValue('en');
     },
     '--sources': () => {
-      options.sourcesSpec = args[++index] ?? '';
+      options.sourcesSpec = nextValue();
     },
     '--override': () => {
-      options.overrideFile = args[++index] ?? '';
+      options.overrideFile = nextValue();
     },
     '--no-repo-overrides': () => {
       options.noRepoOverrides = true;
     },
     '--articles': () => {
-      options.articlesPath = args[++index] ?? '';
+      options.articlesPath = nextValue();
     },
     '--skip-list': () => {
-      options.skipListPath = args[++index] ?? '';
+      options.skipListPath = nextValue();
     },
     '--fixes': () => {
-      options.translationFixesPath = args[++index] ?? '';
+      options.translationFixesPath = nextValue();
     },
     '--match-threshold': () => {
-      options.matchThreshold = Number(args[++index] ?? '');
+      options.matchThreshold = Number(nextValue());
     },
     '--max-ngram': () => {
-      options.maxNgramSize = Number(args[++index] ?? 3);
+      options.maxNgramSize = Number(nextValue(3));
     },
     '--score': () => {
-      const [id, value] = String(args[++index] ?? '').split('=');
-      const parsed = Number(value);
-      if (id && Number.isFinite(parsed)) {
-        options.evidenceScoring[id] = parsed;
-      }
+      applyEvidenceScore(options.evidenceScoring, nextValue());
+    },
+    '--profile': () => {
+      options.profileFile = nextValue();
+    },
+    '--belief-profile': () => {
+      options.profileFile = nextValue();
+    },
+    '--preference-profile': () => {
+      options.profileFile = nextValue();
     },
     '--help': () => {
       options.command = 'help';
@@ -100,21 +106,298 @@ export function parseCliArguments(args) {
 
   for (index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (index === 0 && !arg.startsWith('-')) {
+    if (isConfigurationOption(arg)) {
+      index += 1;
+      continue;
+    }
+    if (commandSlotOpen && !arg.startsWith('-')) {
       options.command = arg;
+      commandSlotOpen = false;
       continue;
     }
     if (optionHandlers[arg]) {
       optionHandlers[arg]();
+      commandSlotOpen = false;
       continue;
     }
-    options.inputParts.push(arg);
+    appendInputPart(options, arg);
+    commandSlotOpen = false;
   }
 
+  const { inputParts, inputFromConfiguration, ...parsedOptions } = options;
+  void inputFromConfiguration;
   return {
-    ...options,
-    input: options.inputParts.join(' ').trim(),
+    ...parsedOptions,
+    input: inputParts.join(' ').trim(),
   };
+}
+
+function loadCliConfiguration(args) {
+  const originalConsole = {
+    error: console.error,
+    log: console.log,
+    warn: console.warn,
+  };
+  const originalEnv = { ...process.env };
+  console.error = () => {};
+  console.log = () => {};
+  console.warn = () => {};
+  try {
+    return makeConfig({
+      argv: [...cliArgvPrefix, ...args],
+      env: { enabled: false },
+      lenv: { enabled: true, override: true },
+      yargs: configureCliYargs,
+    });
+  } catch {
+    return {};
+  } finally {
+    console.error = originalConsole.error;
+    console.log = originalConsole.log;
+    console.warn = originalConsole.warn;
+    restoreProcessEnv(originalEnv);
+  }
+}
+
+function configureCliYargs({ yargs, getenv }) {
+  return yargs
+    .help(false)
+    .version(false)
+    .exitProcess(false)
+    .parserConfiguration({
+      'camel-case-expansion': true,
+    })
+    .option('command', { type: 'string', default: getenv('COMMAND', '') })
+    .option('input', {
+      alias: 'i',
+      type: 'string',
+      default: getenv('INPUT', ''),
+    })
+    .option('format', {
+      alias: 'f',
+      type: 'string',
+      default: getenv('FORMAT', 'json'),
+    })
+    .option('select', {
+      alias: 's',
+      type: 'number',
+      default: getenv('SELECT', 0),
+    })
+    .option('live', {
+      type: 'boolean',
+      default: getenv('LIVE', false),
+    })
+    .option('target', {
+      type: 'string',
+      default: getenv('TARGET', ''),
+    })
+    .option('target-language', {
+      alias: 'to',
+      type: 'string',
+      default: getenv('TARGET_LANGUAGE', ''),
+    })
+    .option('translation-strategy', {
+      type: 'string',
+      default: getenv('TRANSLATION_STRATEGY', ''),
+    })
+    .option('source-language', {
+      alias: 'from',
+      type: 'string',
+      default: getenv('SOURCE_LANGUAGE', ''),
+    })
+    .option('sources', {
+      type: 'string',
+      default: getenv('SOURCES', ''),
+    })
+    .option('override', {
+      type: 'string',
+      default: getenv('OVERRIDE', ''),
+    })
+    .option('no-repo-overrides', {
+      type: 'boolean',
+      default: getenv('NO_REPO_OVERRIDES', false),
+    })
+    .option('articles', {
+      type: 'string',
+      default: getenv('ARTICLES', ''),
+    })
+    .option('skip-list', {
+      type: 'string',
+      default: getenv('SKIP_LIST', ''),
+    })
+    .option('fixes', {
+      type: 'string',
+      default: getenv('FIXES', ''),
+    })
+    .option('match-threshold', {
+      type: 'number',
+      default: getenv('MATCH_THRESHOLD', Number.NaN),
+    })
+    .option('max-ngram', {
+      type: 'number',
+      default: getenv('MAX_NGRAM', Number.NaN),
+    })
+    .option('score', {
+      type: 'string',
+      default: getenv('SCORE', ''),
+    })
+    .option('profile', {
+      type: 'string',
+      default: getenv('PROFILE', ''),
+    })
+    .option('belief-profile', {
+      type: 'string',
+      default: getenv('BELIEF_PROFILE', ''),
+    })
+    .option('preference-profile', {
+      type: 'string',
+      default: getenv('PREFERENCE_PROFILE', ''),
+    })
+    .option('help', {
+      alias: 'h',
+      type: 'boolean',
+      default: getenv('HELP', false),
+    });
+}
+
+function restoreProcessEnv(originalEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(originalEnv)) {
+    process.env[key] = value;
+  }
+}
+
+function createCliOptions(config) {
+  const input = stringOption(config.input);
+  const options = {
+    command: stringOption(config.command) || 'analyze',
+    format: stringOption(config.format) || 'json',
+    inputParts: input ? [input] : [],
+    inputFromConfiguration: Boolean(input),
+    evidenceScoring: parseEvidenceScoring(config.score),
+  };
+  assignNumberOption(options, 'interpretationIndex', config.select);
+  assignBooleanOption(options, 'live', config.live);
+  assignStringOption(options, 'target', config.target);
+  assignStringOption(
+    options,
+    'targetLanguage',
+    firstPresent(config.targetLanguage, config.to)
+  );
+  assignStringOption(
+    options,
+    'translationStrategy',
+    config.translationStrategy
+  );
+  assignStringOption(
+    options,
+    'sourceLanguage',
+    firstPresent(config.sourceLanguage, config.from)
+  );
+  assignStringOption(options, 'sourcesSpec', config.sources);
+  assignStringOption(options, 'overrideFile', config.override);
+  assignBooleanOption(options, 'noRepoOverrides', config.noRepoOverrides);
+  assignStringOption(options, 'articlesPath', config.articles);
+  assignStringOption(options, 'skipListPath', config.skipList);
+  assignStringOption(options, 'translationFixesPath', config.fixes);
+  assignNumberOption(options, 'matchThreshold', config.matchThreshold);
+  assignNumberOption(options, 'maxNgramSize', config.maxNgram);
+  assignStringOption(
+    options,
+    'profileFile',
+    firstPresent(config.profile, config.beliefProfile, config.preferenceProfile)
+  );
+  if (config.help === true) {
+    options.command = 'help';
+  }
+  return options;
+}
+
+function isConfigurationOption(arg) {
+  return arg === '--configuration' || arg === '-c';
+}
+
+function appendInputPart(options, value) {
+  if (options.inputFromConfiguration) {
+    options.inputParts.length = 0;
+    options.inputFromConfiguration = false;
+  }
+  options.inputParts.push(value ?? '');
+}
+
+function parseEvidenceScoring(value) {
+  const scoring = {};
+  applyEvidenceScore(scoring, value);
+  return scoring;
+}
+
+function applyEvidenceScore(scoring, value) {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+  const entries = Array.isArray(value) ? value : String(value).split(',');
+  for (const entry of entries) {
+    const [id, score] = String(entry).split('=');
+    const parsed = Number(score);
+    if (id && Number.isFinite(parsed)) {
+      scoring[id] = parsed;
+    }
+  }
+}
+
+function firstPresent(...values) {
+  return values.find(
+    (value) => value !== undefined && value !== null && value !== ''
+  );
+}
+
+function assignStringOption(options, key, value) {
+  const parsed = stringOption(value);
+  if (parsed) {
+    options[key] = parsed;
+  }
+}
+
+function assignNumberOption(options, key, value) {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    options[key] = parsed;
+  }
+}
+
+function assignBooleanOption(options, key, value) {
+  const parsed = booleanOption(value);
+  if (parsed !== undefined) {
+    options[key] = parsed;
+  }
+}
+
+function stringOption(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return String(value);
+}
+
+function booleanOption(value) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  return Boolean(value);
 }
 
 export function runCli(args = process.argv.slice(2), output = console) {
@@ -122,6 +405,9 @@ export function runCli(args = process.argv.slice(2), output = console) {
 
   if (options.live) {
     throw new Error('Use runCliAsync for live evidence mode.');
+  }
+  if (options.profileFile) {
+    throw new Error('Use runCliAsync for preference profile files.');
   }
   if (options.command === 'formalize') {
     throw new Error('Use runCliAsync for the formalize command.');
@@ -147,6 +433,7 @@ export function runCli(args = process.argv.slice(2), output = console) {
       output,
       checkText(options.input, {
         evidenceScoring: options.evidenceScoring,
+        preferenceProfile: options.preferenceProfile,
       })
     );
   }
@@ -162,11 +449,12 @@ export async function runCliAsync(
   args = process.argv.slice(2),
   output = console
 ) {
-  const options = parseCliArguments(args);
+  let options = parseCliArguments(args);
   const checked = validateCliOptions(options, output);
   if (checked !== null) {
     return checked;
   }
+  options = await hydrateCliOptions(options);
   if (options.command === 'formalize') {
     return runFormalizeCommand(options, output);
   }
@@ -272,11 +560,36 @@ async function runCheckCommand(options, output) {
     ? await checkTextWithLiveEvidence(options.input, {
         fetch: globalThis.fetch?.bind(globalThis),
         evidenceScoring: options.evidenceScoring,
+        preferenceProfile: options.preferenceProfile,
       })
     : checkText(options.input, {
         evidenceScoring: options.evidenceScoring,
+        preferenceProfile: options.preferenceProfile,
       });
   return emitCheckResult(options, output, result);
+}
+
+async function hydrateCliOptions(options) {
+  if (!options.profileFile) {
+    return options;
+  }
+  const raw = await readFile(options.profileFile, 'utf8');
+  const preferenceProfile = parseCliPreferenceProfile(raw);
+  return {
+    ...options,
+    preferenceProfile,
+  };
+}
+
+function parseCliPreferenceProfile(raw) {
+  const trimmed = String(raw ?? '').trim();
+  if (!trimmed) {
+    return parsePreferenceProfile('');
+  }
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    return JSON.parse(trimmed);
+  }
+  return parsePreferenceProfile(raw);
 }
 
 async function runTranslationQualityCommand(options, output) {
@@ -413,6 +726,7 @@ function cliAnalysisOptions(options) {
     interpretationIndex: options.interpretationIndex ?? 0,
     selectedBy: 'cli',
     evidenceScoring: options.evidenceScoring,
+    preferenceProfile: options.preferenceProfile,
   };
 }
 
@@ -510,6 +824,9 @@ Options:
   --sources <spec>               formalize: comma-separated sources
                                    (wikidata,wordnet,fandom:<slug>,fandom-host:<host>)
   --override <file.lino|.json>   formalize: extra user override file (.lino preferred)
+  --configuration, -c <file.lenv>
+                                 Load CLI defaults from a Links Notation env file
+  --profile <file.lino|.json>    analyze/check: preference or belief profile
   --no-repo-overrides            formalize: ignore docs/formalize/overrides.lino
   --max-ngram <n>                formalize: maximum n-gram size (default 3)
   --articles <file.json>         translation-quality: fixture with article extracts

--- a/js/src/lino.js
+++ b/js/src/lino.js
@@ -25,7 +25,10 @@
  * strings — mirroring the unicode-sequence handling in link-cli.
  */
 
+import { Parser as LinksNotationParser } from 'links-notation';
+
 const QUOTE = '"';
+const officialLinksParser = new LinksNotationParser();
 
 /**
  * Parse an indented .lino document into a JS value.
@@ -38,7 +41,102 @@ const QUOTE = '"';
  * @returns {unknown}
  */
 export function parseLino(text) {
-  const lines = stripComments(String(text ?? '')).split('\n');
+  const source = stripComments(String(text ?? ''));
+  if (!source.trim()) {
+    return null;
+  }
+  if (looksLikeOfficialLinksNotation(source)) {
+    const parsed = parseOfficialLinksNotation(source);
+    if (parsed.ok) {
+      return parsed.value;
+    }
+  }
+  return parseLegacyLino(source);
+}
+
+function parseOfficialLinksNotation(text) {
+  try {
+    const links = officialLinksParser.parse(text);
+    return { ok: true, value: materializeOfficialLinks(links) };
+  } catch {
+    return { ok: false, value: null };
+  }
+}
+
+function materializeOfficialLinks(links) {
+  if (!Array.isArray(links) || links.length === 0) {
+    return null;
+  }
+  const values = links.map(materializeOfficialLink);
+  return values.length === 1 ? values[0] : values;
+}
+
+function materializeOfficialLink(link) {
+  const values = Array.isArray(link?.values)
+    ? link.values.map(materializeOfficialLink)
+    : [];
+  if (link?.id !== null && link?.id !== undefined) {
+    const key = String(decodeToken(link.id));
+    if (values.length === 0) {
+      return decodeToken(link.id);
+    }
+    return {
+      [key]: values.length === 1 ? values[0] : values,
+    };
+  }
+  if (values.length === 0) {
+    return null;
+  }
+  return values.length === 1 ? values[0] : values;
+}
+
+function looksLikeOfficialLinksNotation(text) {
+  return text
+    .split('\n')
+    .some((line) => looksLikeOfficialLinksLine(line.trim()));
+}
+
+function looksLikeOfficialLinksLine(line) {
+  if (!line) {
+    return false;
+  }
+  if (line.startsWith('(') && line.endsWith(')')) {
+    return true;
+  }
+  return hasUnquotedColon(line);
+}
+
+function hasUnquotedColon(line) {
+  let quote = null;
+  let escaped = false;
+  for (const char of line) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === QUOTE || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === ':') {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseLegacyLino(text) {
+  const lines = text.split('\n');
   const stack = [];
   const root = { indent: -1, children: [], identifier: null, parent: null };
   stack.push(root);

--- a/js/tests/e2e/issue-62.test.js
+++ b/js/tests/e2e/issue-62.test.js
@@ -1,0 +1,76 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect } from 'test-anywhere';
+import { parseCliArguments, runCliAsync } from '../../src/cli.js';
+import { parseLino, serializePreferenceProfile } from '../../src/index.js';
+
+describe('issue 62 - official Links Notation and lino-arguments', () => {
+  it('parses official Links Notation tuples through the current Lino API', () => {
+    const parsed = parseLino('(claim: Earth Sun)\n');
+
+    expect(parsed).toEqual({ claim: ['Earth', 'Sun'] });
+  });
+
+  it('loads CLI defaults from a Links Notation configuration file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'meta-expression-issue-62-'));
+    try {
+      const configPath = join(dir, 'meta-expression.lenv');
+      await writeFile(
+        configPath,
+        [
+          'COMMAND: check',
+          'INPUT: Earth orbits the Sun.',
+          'FORMAT: markdown',
+          'SCORE: wikipedia-cited-statement=0.8',
+          '',
+        ].join('\n')
+      );
+
+      const parsed = parseCliArguments(['--configuration', configPath]);
+
+      expect(parsed.command).toBe('check');
+      expect(parsed.input).toBe('Earth orbits the Sun.');
+      expect(parsed.format).toBe('markdown');
+      expect(parsed.evidenceScoring['wikipedia-cited-statement']).toBe(0.8);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('applies a Links Notation preference profile from the CLI', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'meta-expression-issue-62-'));
+    try {
+      const profilePath = join(dir, 'profile.lino');
+      await writeFile(
+        profilePath,
+        serializePreferenceProfile({ activeContextId: 'star-wars' })
+      );
+      const logs = [];
+      const errors = [];
+
+      const exit = await runCliAsync(
+        ['analyze', '--input', 'The Force exists', '--profile', profilePath],
+        {
+          log(message) {
+            logs.push(message);
+          },
+          error(message) {
+            errors.push(message);
+          },
+        }
+      );
+      const result = JSON.parse(logs[0]);
+
+      expect(exit).toBe(0);
+      expect(errors.length).toBe(0);
+      expect(
+        result.result.supportingEvidence.some(
+          (evidence) => evidence.sourceType === 'context'
+        )
+      ).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "meta-expression",
       "version": "0.9.0",
       "license": "Unlicense",
+      "dependencies": {
+        "links-notation": "^0.13.0",
+        "lino-arguments": "^0.3.0"
+      },
       "bin": {
         "meta-expression": "js/src/cli.js"
       },
@@ -947,7 +951,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -957,7 +960,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1263,11 +1265,70 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1280,7 +1341,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -1488,6 +1548,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1998,6 +2067,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
@@ -2064,6 +2142,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/gitignore-to-glob": {
@@ -2657,6 +2744,56 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/links-notation": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/links-notation/-/links-notation-0.13.0.tgz",
+      "integrity": "sha512-52FoUAVOhjfC23bdvrxv6b4Eosp02WeM3qTN9Rsb3ouPof5YVQ5fOMlRPMJmKMmdseVzEnewNLFq3lADRpWTFg==",
+      "license": "Unlicense"
+    },
+    "node_modules/lino-arguments": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/lino-arguments/-/lino-arguments-0.3.0.tgz",
+      "integrity": "sha512-46RbNaq0kpDxjyzBqhiCjPypHy9tuL0ITC9LgEolFH65PKtwl0/kRxryleG+5HnqS1JLnUUypZ2GoHWhLWH/PQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "getenv": "^2.0.0",
+        "links-notation": "^0.11.2",
+        "lino-env": "^0.2.6",
+        "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@dotenvx/dotenvx": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@dotenvx/dotenvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lino-arguments/node_modules/links-notation": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz",
+      "integrity": "sha512-VPyELWBXpaCCiNPVeZhMbG7RuvOQR51nhqELK+s/rbSzKYhSs+tyiSOdQ7z8I7Kh3PLABF3bZETtWSFwx3vFfg==",
+      "license": "Unlicense"
+    },
+    "node_modules/lino-env": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/lino-env/-/lino-env-0.2.8.tgz",
+      "integrity": "sha512-j9JcPo8LWCSlWCO7B1SSL3OlpRc/bGaR/OYnH22DTiANaMaLWan7ebRIo2Pwaw/apcIzdV+UD5EXamdapbn6kA==",
+      "license": "Unlicense",
+      "dependencies": {
+        "links-notation": "^0.11.2"
+      }
+    },
+    "node_modules/lino-env/node_modules/links-notation": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz",
+      "integrity": "sha512-VPyELWBXpaCCiNPVeZhMbG7RuvOQR51nhqELK+s/rbSzKYhSs+tyiSOdQ7z8I7Kh3PLABF3bZETtWSFwx3vFfg==",
+      "license": "Unlicense"
     },
     "node_modules/lint-staged": {
       "version": "16.2.7",
@@ -3520,6 +3657,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -3791,7 +3937,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4122,6 +4267,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -4146,6 +4300,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -85,5 +85,9 @@
       "prettier --write",
       "prettier --check"
     ]
+  },
+  "dependencies": {
+    "links-notation": "^0.13.0",
+    "lino-arguments": "^0.3.0"
   }
 }


### PR DESCRIPTION
Fixes #62

## Summary
- Add runtime dependencies on `links-notation@0.13.0` and `lino-arguments@0.3.0`.
- Route official Links Notation forms through the official parser while keeping the existing indented Lino fallback and serializer output stable.
- Load CLI defaults from `.lenv` / `--configuration` through `lino-arguments`, preserving existing positional parsing behavior.
- Add `--profile`, `--belief-profile`, and `--preference-profile` support so analyze/check commands can hydrate belief preference profiles.
- Add issue 62 e2e coverage plus a minor Changeset release note.

## Reproduction
The new `js/tests/e2e/issue-62.test.js` covers the pre-fix failures: official tuple parsing through `parseLino`, `.lenv` CLI defaults, and CLI profile evidence from a Links Notation preference profile.

## Verification
- `node --test js/tests/e2e/issue-62.test.js`
- `node --test js/tests/e2e/issue-15.test.js js/tests/e2e/issue-16.test.js js/tests/e2e/issue-17.test.js js/tests/e2e/issue-27.test.js js/tests/integration/issue-18.test.js js/tests/integration/issue-21-snapshot-cache.test.js`
- `npm test`
- `npm run check`
- `npm run changeset:status`