### PR TITLE
feat: add Links Notation rewrite transformations

### DIFF
--- a/.changeset/issue-65-links-rewrite-engine.md
+++ b/.changeset/issue-65-links-rewrite-engine.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': minor
+---
+
+Add a Links Notation rewrite and simplify transformation engine with traceable hook integration.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-25T19:10:31.966Z for PR creation at branch issue-60-b3b07b32a4f2 for issue https://github.com/link-assistant/meta-expression/issues/60
 # Updated: 2026-05-25T20:24:10.008Z
+# Updated: 2026-05-25T21:31:06.821Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-25T19:10:31.966Z for PR creation at branch issue-60-b3b07b32a4f2 for issue https://github.com/link-assistant/meta-expression/issues/60
 # Updated: 2026-05-25T20:24:10.008Z
-# Updated: 2026-05-25T21:31:06.821Z

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -645,6 +645,8 @@ export type TransformationRule =
       id?: string;
       assign: Record<string, unknown>;
     }
+  | LinksNotationRewriteTransformationRule
+  | LinksNotationSimplifyTransformationRule
   | {
       id?: string;
       apply(
@@ -662,6 +664,101 @@ export interface TransformationContext {
   steps: TranslationStep[];
   trace?: boolean;
 }
+
+export type LinksNotationRewriteDirection =
+  | 'forward'
+  | 'left-to-right'
+  | '->'
+  | 'backward'
+  | 'right-to-left'
+  | '<-'
+  | 'reverse';
+
+export type LinksNotationRewriteOccurrence = 'all' | 'first' | number | string;
+
+export type LinksNotationRewriteEquality =
+  | string
+  | {
+      from: string;
+      to: string;
+    }
+  | {
+      left: string;
+      right: string;
+    };
+
+export interface LinksNotationRewriteOptions {
+  direction?: LinksNotationRewriteDirection;
+  occurrence?: LinksNotationRewriteOccurrence;
+  at?: LinksNotationRewriteOccurrence;
+}
+
+export interface LinksNotationSimplifyOptions {
+  direction?: LinksNotationRewriteDirection;
+  maxSteps?: number;
+  simplifyMaxSteps?: number;
+}
+
+export interface LinksNotationRewriteTransformationRule extends LinksNotationRewriteOptions {
+  id?: string;
+  rewrite:
+    | LinksNotationRewriteEquality
+    | ({
+        equality?: LinksNotationRewriteEquality;
+      } & LinksNotationRewriteOptions)
+    | ({ rule?: LinksNotationRewriteEquality } & LinksNotationRewriteOptions)
+    | ({ eq?: LinksNotationRewriteEquality } & LinksNotationRewriteOptions);
+  target?: string | string[];
+  path?: string | string[];
+}
+
+export interface LinksNotationSimplifyTransformationRule extends LinksNotationSimplifyOptions {
+  id?: string;
+  simplify:
+    | true
+    | LinksNotationRewriteEquality
+    | LinksNotationRewriteEquality[]
+    | ({
+        rules?: LinksNotationRewriteEquality | LinksNotationRewriteEquality[];
+        rewriteRules?:
+          | LinksNotationRewriteEquality
+          | LinksNotationRewriteEquality[];
+      } & LinksNotationSimplifyOptions);
+  rules?: LinksNotationRewriteEquality | LinksNotationRewriteEquality[];
+  rewriteRules?: LinksNotationRewriteEquality | LinksNotationRewriteEquality[];
+  target?: string | string[];
+  path?: string | string[];
+}
+
+export declare function rewriteLinksNotation(
+  value: string,
+  equality: LinksNotationRewriteEquality,
+  options?: LinksNotationRewriteOptions
+): string;
+
+export declare function simplifyLinksNotation(
+  value: string,
+  rules: LinksNotationRewriteEquality | LinksNotationRewriteEquality[],
+  options?: LinksNotationSimplifyOptions
+): string;
+
+export declare function applyTextTransformationRules(
+  value: unknown,
+  rules?: TransformationRule | TransformationRule[],
+  context?: Partial<TransformationContext>
+): Promise<string>;
+
+export declare function applyObjectTransformationRules<T>(
+  value: T,
+  rules?: TransformationRule | TransformationRule[],
+  context?: Partial<TransformationContext>
+): Promise<T>;
+
+export declare function applySentenceTextTransformationRules(
+  sentences: TranslationSentence[],
+  rules?: TransformationRule | TransformationRule[],
+  context?: Partial<TransformationContext>
+): Promise<TranslationSentence[]>;
 
 export interface FormalizeInterpretation {
   rank: number;

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -121,6 +121,13 @@ export {
   tokenizeLino,
 } from './lino.js';
 export {
+  applyObjectTransformationRules,
+  applySentenceTextTransformationRules,
+  applyTextTransformationRules,
+  rewriteLinksNotation,
+  simplifyLinksNotation,
+} from './transformation-rules.js';
+export {
   createDefaultPreferenceProfile,
   createPreferenceEvidence,
   getPreferenceEvidenceSituationProbability,

--- a/js/src/transformation-rules.js
+++ b/js/src/transformation-rules.js
@@ -1,3 +1,12 @@
+import {
+  Link,
+  Parser as LinksNotationParser,
+  formatLinks,
+} from 'links-notation';
+
+const linksNotationParser = new LinksNotationParser();
+const defaultSimplifyMaxSteps = 1000;
+
 export function collectTransformationRules(options, names) {
   const rules = [];
   for (const name of names) {
@@ -59,13 +68,53 @@ export function applyObjectTransformationRules(value, rules, context = {}) {
   return applyTransformationRules(value, rules, context);
 }
 
+export function rewriteLinksNotation(value, equality, options = {}) {
+  const term = parseLinksNotationTerm(value, 'rewrite goal');
+  const equalityTerm = normalizeRewriteEquality(equality);
+  const rewritten = rewriteLinksNotationTerm(term, equalityTerm, options);
+  return rewritten.changed ? formatLinksNotationTerm(rewritten.node) : value;
+}
+
+export function simplifyLinksNotation(value, rules, options = {}) {
+  const ruleTerms = normalizeRewriteRules(rules);
+  const maxSteps = normalizeSimplifyMaxSteps(options);
+  let term = parseLinksNotationTerm(value, 'simplify goal');
+  let changed = false;
+  let steps = 0;
+
+  while (true) {
+    let applied = false;
+    for (const rule of ruleTerms) {
+      const rewritten = rewriteLinksNotationTerm(term, rule, {
+        direction: options.direction,
+      });
+      if (!rewritten.changed) {
+        continue;
+      }
+      if (steps >= maxSteps) {
+        throw new Error(
+          `simplify termination guard reached after ${maxSteps} rewrite steps`
+        );
+      }
+      term = rewritten.node;
+      steps += 1;
+      changed = true;
+      applied = true;
+      break;
+    }
+    if (!applied) {
+      return changed ? formatLinksNotationTerm(term) : value;
+    }
+  }
+}
+
 export async function applySentenceTextTransformationRules(
   sentences,
   rules,
   context = {}
 ) {
   let current = sentences.map(cloneSentence);
-  for (const rule of rules ?? []) {
+  for (const rule of normalizeTransformationRuleList(rules)) {
     const before = sentenceSummary(current);
     current = await Promise.all(
       current.map((sentence) => applySentenceRule(sentence, rule, context))
@@ -77,13 +126,20 @@ export async function applySentenceTextTransformationRules(
 
 async function applyTransformationRules(value, rules, context) {
   let current = value;
-  for (const rule of rules ?? []) {
+  for (const rule of normalizeTransformationRuleList(rules)) {
     const before = summarizeValue(current);
     const next = await applyRule(current, rule, context);
     current = next === undefined ? current : next;
     recordTransformationStep(context, rule, before, summarizeValue(current));
   }
   return current;
+}
+
+function normalizeTransformationRuleList(rules) {
+  if (rules === undefined || rules === null) {
+    return [];
+  }
+  return Array.isArray(rules) ? rules : [rules];
 }
 
 async function applySentenceRule(sentence, rule, context) {
@@ -98,6 +154,12 @@ async function applyRule(value, rule, context) {
   const custom = await applyCustomRule(value, rule, context);
   if (custom !== undefined) {
     return custom;
+  }
+  if (hasLinksNotationRewrite(rule)) {
+    return applyLinksNotationRewriteRule(value, rule);
+  }
+  if (hasLinksNotationSimplify(rule)) {
+    return applyLinksNotationSimplifyRule(value, rule);
   }
   if (typeof value === 'string') {
     return applyStringRule(value, rule);
@@ -116,6 +178,319 @@ function applyCustomRule(value, rule, context) {
     return rule.apply(value, context);
   }
   return undefined;
+}
+
+function applyLinksNotationRewriteRule(value, rule) {
+  const rewriteSpec = rule.rewrite;
+  const specOptions = isPlainObject(rewriteSpec) ? rewriteSpec : {};
+  const equality =
+    specOptions.equality ?? specOptions.rule ?? specOptions.eq ?? rewriteSpec;
+  return applyLinksNotationTransform(value, rule, (linksNotation) =>
+    rewriteLinksNotation(linksNotation, equality, {
+      direction: rule.direction ?? specOptions.direction,
+      occurrence:
+        rule.occurrence ?? specOptions.occurrence ?? rule.at ?? specOptions.at,
+    })
+  );
+}
+
+function applyLinksNotationSimplifyRule(value, rule) {
+  const simplifySpec = rule.simplify;
+  const specOptions = isPlainObject(simplifySpec) ? simplifySpec : {};
+  const rules =
+    specOptions.rules ??
+    specOptions.rewriteRules ??
+    (simplifySpec === true ? (rule.rules ?? rule.rewriteRules) : simplifySpec);
+  return applyLinksNotationTransform(value, rule, (linksNotation) =>
+    simplifyLinksNotation(linksNotation, rules, {
+      direction: rule.direction ?? specOptions.direction,
+      maxSteps:
+        rule.maxSteps ??
+        rule.simplifyMaxSteps ??
+        specOptions.maxSteps ??
+        specOptions.simplifyMaxSteps,
+    })
+  );
+}
+
+function applyLinksNotationTransform(value, rule, transform) {
+  const targetPath = normalizeTargetPath(rule.target ?? rule.path);
+  if (targetPath.length > 0) {
+    return transformValueAtPath(value, targetPath, transform);
+  }
+  if (typeof value === 'string') {
+    return transform(value);
+  }
+  return value;
+}
+
+function transformValueAtPath(value, path, transform) {
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const current = valueAtPath(value, path);
+  if (typeof current !== 'string') {
+    return value;
+  }
+  const next = transform(current);
+  if (next === current) {
+    return value;
+  }
+  return setValueAtPath(value, path, next);
+}
+
+function valueAtPath(value, path) {
+  let current = value;
+  for (const segment of path) {
+    if (!isPlainObject(current) || !Object.hasOwn(current, segment)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function setValueAtPath(value, path, nextValue) {
+  if (path.length === 0) {
+    return nextValue;
+  }
+  const [head, ...tail] = path;
+  return {
+    ...value,
+    [head]: tail.length
+      ? setValueAtPath(value[head], tail, nextValue)
+      : nextValue,
+  };
+}
+
+function normalizeTargetPath(path) {
+  if (Array.isArray(path)) {
+    return path.map(String).filter(Boolean);
+  }
+  if (typeof path === 'string' && path.trim()) {
+    return path
+      .split('.')
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function hasLinksNotationRewrite(rule) {
+  return (
+    isPlainObject(rule) && Object.prototype.hasOwnProperty.call(rule, 'rewrite')
+  );
+}
+
+function hasLinksNotationSimplify(rule) {
+  return (
+    isPlainObject(rule) &&
+    Object.prototype.hasOwnProperty.call(rule, 'simplify')
+  );
+}
+
+function rewriteLinksNotationTerm(goal, equality, options = {}) {
+  const { from, to } = rewriteSides(equality, options.direction);
+  return rewriteNode(goal, from, to, options.occurrence);
+}
+
+function rewriteSides(equality, direction) {
+  const sides = equalitySides(equality);
+  if (!sides) {
+    throw new Error('rewrite expects an equality link');
+  }
+  if (normalizeRewriteDirection(direction) === 'backward') {
+    return { from: sides.right, to: sides.left };
+  }
+  return { from: sides.left, to: sides.right };
+}
+
+function rewriteNode(node, from, to, occurrence) {
+  const selected = normalizeRewriteOccurrence(occurrence);
+  let seen = 0;
+  let count = 0;
+
+  function walk(current) {
+    if (isSameLinksNotationTerm(current, from)) {
+      seen += 1;
+      if (selected.kind === 'all' || seen === selected.index) {
+        count += 1;
+        return cloneLinksNotationTerm(to);
+      }
+    }
+    if (!isLinksNotationLink(current)) {
+      return current;
+    }
+    return new Link(
+      current.id ?? null,
+      current.values.map((item) => walk(item))
+    );
+  }
+
+  return { node: walk(node), changed: count > 0, count, seen };
+}
+
+function normalizeRewriteRules(rules) {
+  if (rules === undefined || rules === null) {
+    return [];
+  }
+  if (typeof rules === 'string') {
+    const parsed = linksNotationParser.parse(rules);
+    return parsed.map(normalizeRewriteEquality);
+  }
+  if (Array.isArray(rules) && !isLinksNotationLink(rules)) {
+    return rules.map(normalizeRewriteEquality);
+  }
+  return [normalizeRewriteEquality(rules)];
+}
+
+function normalizeRewriteEquality(equality) {
+  if (isPlainObject(equality)) {
+    const left = equality.from ?? equality.left;
+    const right = equality.to ?? equality.right;
+    if (left !== undefined && right !== undefined) {
+      return new Link(null, [
+        parseRewriteSide(left, 'rewrite left side'),
+        new Link('='),
+        parseRewriteSide(right, 'rewrite right side'),
+      ]);
+    }
+  }
+  const term = parseLinksNotationTerm(equality, 'rewrite equality');
+  if (!equalitySides(term)) {
+    throw new Error(
+      `rewrite expects an equality link (got ${formatLinksNotationTerm(term)})`
+    );
+  }
+  return term;
+}
+
+function parseRewriteSide(value, label) {
+  const term = parseLinksNotationTerm(value, label);
+  if (term.id === null && term.values.length === 1) {
+    return term.values[0];
+  }
+  return term;
+}
+
+function equalitySides(term) {
+  if (!isLinksNotationLink(term)) {
+    return null;
+  }
+  if (term.id === '=' && term.values.length === 2) {
+    return { left: term.values[0], right: term.values[1] };
+  }
+  if (
+    term.id === null &&
+    term.values.length === 3 &&
+    isReferenceLink(term.values[1], '=')
+  ) {
+    return { left: term.values[0], right: term.values[2] };
+  }
+  return null;
+}
+
+function parseLinksNotationTerm(value, label) {
+  if (isLinksNotationLink(value)) {
+    return cloneLinksNotationTerm(value);
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be Links Notation text or a link object`);
+  }
+  const parsed = linksNotationParser.parse(value);
+  if (parsed.length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+  if (parsed.length === 1) {
+    return cloneLinksNotationTerm(parsed[0]);
+  }
+  return new Link(null, parsed.map(cloneLinksNotationTerm));
+}
+
+function formatLinksNotationTerm(term) {
+  return formatLinks([term]);
+}
+
+function normalizeRewriteDirection(direction = 'forward') {
+  if (direction === undefined || direction === null) {
+    return 'forward';
+  }
+  const raw = String(direction);
+  if (raw === 'forward' || raw === 'left-to-right' || raw === '->') {
+    return 'forward';
+  }
+  if (
+    raw === 'backward' ||
+    raw === 'right-to-left' ||
+    raw === '<-' ||
+    raw === 'reverse'
+  ) {
+    return 'backward';
+  }
+  throw new Error(`unknown rewrite direction "${raw}"`);
+}
+
+function normalizeRewriteOccurrence(occurrence = 'all') {
+  if (occurrence === undefined || occurrence === null || occurrence === 'all') {
+    return { kind: 'all' };
+  }
+  if (occurrence === 'first') {
+    return { kind: 'index', index: 1 };
+  }
+  const index =
+    typeof occurrence === 'number' ? occurrence : Number(String(occurrence));
+  if (Number.isSafeInteger(index) && index >= 1) {
+    return { kind: 'index', index };
+  }
+  throw new Error(
+    `rewrite occurrence must be "all", "first", or a positive integer`
+  );
+}
+
+function normalizeSimplifyMaxSteps(options = {}) {
+  const raw =
+    options.maxSteps ?? options.simplifyMaxSteps ?? defaultSimplifyMaxSteps;
+  const maxSteps = typeof raw === 'number' ? raw : Number(String(raw));
+  if (!Number.isSafeInteger(maxSteps) || maxSteps < 0) {
+    throw new Error(
+      `simplify maxSteps must be a non-negative integer (got ${String(raw)})`
+    );
+  }
+  return maxSteps;
+}
+
+function isSameLinksNotationTerm(left, right) {
+  if (!isLinksNotationLink(left) || !isLinksNotationLink(right)) {
+    return left === right;
+  }
+  if (left.id !== right.id || left.values.length !== right.values.length) {
+    return false;
+  }
+  return left.values.every((item, index) =>
+    isSameLinksNotationTerm(item, right.values[index])
+  );
+}
+
+function cloneLinksNotationTerm(term) {
+  if (!isLinksNotationLink(term)) {
+    return term;
+  }
+  return new Link(
+    term.id ?? null,
+    term.values.map((item) => cloneLinksNotationTerm(item))
+  );
+}
+
+function isLinksNotationLink(value) {
+  return (
+    Boolean(value) && typeof value === 'object' && Array.isArray(value.values)
+  );
+}
+
+function isReferenceLink(value, id) {
+  return (
+    isLinksNotationLink(value) && value.id === id && value.values.length === 0
+  );
 }
 
 function applyTextRuleToSentence(sentence, rule) {

--- a/js/tests/integration/issue-65.test.js
+++ b/js/tests/integration/issue-65.test.js
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'test-anywhere';
+import {
+  applyObjectTransformationRules,
+  applyTextTransformationRules,
+  rewriteLinksNotation,
+  simplifyLinksNotation,
+} from '../../src/transformation-rules.js';
+
+describe('issue 65 - Links Notation rewrite transformations', () => {
+  it('rewrites Links Notation terms with RML-style direction and occurrence controls', () => {
+    expect(rewriteLinksNotation('((f a) = (f a))', '(a = b)')).toBe(
+      '((f b) = (f b))'
+    );
+    expect(
+      rewriteLinksNotation('(b = b)', '(a = b)', { direction: 'backward' })
+    ).toBe('(a = a)');
+    expect(
+      rewriteLinksNotation('((pair a a) = (pair b a))', '(a = b)', {
+        occurrence: 2,
+      })
+    ).toBe('((pair a b) = (pair b a))');
+  });
+
+  it('simplifies Links Notation with a guarded repeated rewrite set', () => {
+    expect(simplifyLinksNotation('((f a) = (f a))', ['(a = b)'])).toBe(
+      '((f b) = (f b))'
+    );
+    expect(() =>
+      simplifyLinksNotation('(a = a)', ['(a = b)', '(b = a)'], {
+        maxSteps: 3,
+      })
+    ).toThrow(/termination guard/i);
+  });
+
+  it('runs declarative rewrite and simplify rules through existing transformation hooks', async () => {
+    const steps = [];
+    const result = await applyTextTransformationRules(
+      '((pair a a) = (pair a a))',
+      [
+        {
+          id: 'rewrite-second-a',
+          rewrite: '(a = b)',
+          occurrence: 2,
+        },
+        {
+          id: 'simplify-b-to-c',
+          simplify: ['(b = c)'],
+        },
+      ],
+      { phase: 'links-rewrite', steps }
+    );
+
+    expect(result).toBe('((pair a c) = (pair a a))');
+    expect(steps.map((step) => step.rule)).toEqual([
+      'rewrite-second-a',
+      'simplify-b-to-c',
+    ]);
+    expect(
+      steps.every((step) => step.type === 'custom-transformation-rule')
+    ).toBe(true);
+  });
+
+  it('rewrites a targeted Links Notation field on object transformations', async () => {
+    const result = await applyObjectTransformationRules(
+      { linksNotation: '(a = a)', untouched: true },
+      {
+        id: 'rewrite-links-field',
+        target: 'linksNotation',
+        rewrite: { from: 'a', to: 'b' },
+        occurrence: 'first',
+      }
+    );
+
+    expect(result).toEqual({
+      linksNotation: '(b = a)',
+      untouched: true,
+    });
+  });
+
+  it('keeps zero-config hook behavior for legacy text rules', async () => {
+    const steps = [];
+    const result = await applyTextTransformationRules(
+      'kitten',
+      [{ id: 'kitten-to-cat', pattern: 'kitten', replacement: 'cat' }],
+      { phase: 'legacy', steps }
+    );
+
+    expect(result).toBe('cat');
+    expect(steps.map((step) => step.rule)).toEqual(['kitten-to-cat']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #65.

Promotes the existing transformation hook module into a Links Notation rewrite surface while keeping the current zero-config behavior. The implementation adds:

- `rewriteLinksNotation()` with RML-style structural equality replacement, direction controls (`forward`, `backward`, `->`, `<-`), and occurrence selection (`all`, `first`, or a 1-based index).
- `simplifyLinksNotation()` with guarded repeated rewrite rules and a `maxSteps` termination limit.
- Declarative transformation rules through existing hooks: `{ rewrite: '(a = b)' }`, `{ simplify: ['(a = b)'] }`, and targeted object paths such as `{ target: 'linksNotation', rewrite: { from: 'a', to: 'b' } }`.
- Public JS exports, TypeScript declarations, and a changeset.

I inspected the current upstream `link-foundation/relative-meta-logic` JS API before implementing this slice. Its JS package is currently `relative-meta-logic@0.19.0` under the upstream repo's `js/` subdirectory and is still not published as `relative-meta-logic` on npm, so this PR adopts the rewrite/simplify semantics locally without pinning the unpublished dependency.

## Reproduction / Verification

Before the fix, the new issue-65 test failed because `rewriteLinksNotation` was not exported and no rewrite engine existed in `js/src/transformation-rules.js`.

Automated coverage added in `js/tests/integration/issue-65.test.js` verifies:

- structural Links Notation rewrite
- backward rewrite direction
- selected occurrence rewrite
- guarded simplification loop
- declarative hook trace preservation
- targeted object-field rewrites
- legacy regex transformation behavior remains unchanged

## Checks

- `node --test js/tests/integration/issue-65.test.js`
- `node --test js/tests/integration/issue-54.test.js`
- `npx prettier --check js/src/transformation-rules.js js/src/index.js js/src/index.d.ts js/tests/integration/issue-65.test.js .changeset/issue-65-links-rewrite-engine.md`
- `npm run lint`
- `npm test`
- `npm run check`
- `git diff --check`
