### PR TITLE
docs: refresh competitor parity matrix

### DIFF
--- a/.changeset/issue-71-competitor-parity.md
+++ b/.changeset/issue-71-competitor-parity.md
@@ -1,0 +1,7 @@
+---
+'meta-expression': patch
+---
+
+Refresh the competitor comparison matrices with 2026-05-26 pricing and
+capability research, and add issue #71 parity ledgers for missing features and
+follow-up issues.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T00:15:43.690Z for PR creation at branch issue-71-213699cb7a07 for issue https://github.com/link-assistant/meta-expression/issues/71

--- a/docs/COMPARISON-CONCEPTS.md
+++ b/docs/COMPARISON-CONCEPTS.md
@@ -1,8 +1,13 @@
 # Concept comparison: meta-expression vs. similar projects
 
-> Last checked: 2026-05-11.
-> Source case study: [`docs/case-studies/issue-26/`](./case-studies/issue-26/).
-> Raw research log: [`docs/case-studies/issue-26/ONLINE-RESEARCH.md`](./case-studies/issue-26/ONLINE-RESEARCH.md).
+> Last checked: 2026-05-26.
+> Source case studies:
+> [`docs/case-studies/issue-26/`](./case-studies/issue-26/) and
+> [`docs/case-studies/issue-71/`](./case-studies/issue-71/).
+> Raw research log:
+> [`docs/case-studies/issue-71/ONLINE-RESEARCH.md`](./case-studies/issue-71/ONLINE-RESEARCH.md).
+> Baseline research log:
+> [`docs/case-studies/issue-26/ONLINE-RESEARCH.md`](./case-studies/issue-26/ONLINE-RESEARCH.md).
 
 This document maps meta-expression's concepts (statement interpretation,
 formalization, evidence with provenance, formal evaluation, translation,
@@ -36,8 +41,9 @@ When a comparable system's pricing or license changes:
 
 1. Update the row below.
 2. Update the corresponding row in
-   [`docs/case-studies/issue-26/ONLINE-RESEARCH.md`](./case-studies/issue-26/ONLINE-RESEARCH.md)
-   §A.
+   the current issue refresh log, such as
+   [`docs/case-studies/issue-71/ONLINE-RESEARCH.md`](./case-studies/issue-71/ONLINE-RESEARCH.md)
+   §B.
 3. Bump the `Last checked` date at the top of both files.
 
 When a comparable system ships or removes a feature:
@@ -58,7 +64,7 @@ evidence.
 | ClaimBuster                      | Free academic           | Free with key             | <https://idir.uta.edu/claimbuster/>                  | Check-worthiness score 0..1; meta-expression maps to `correctness`. |
 | Full Fact AI                     | Proprietary partnership | Free for non-profit       | <https://fullfact.ai/>                               | UK political fact monitoring; some OSS components.                  |
 | FactStream (Duke Reporters' Lab) | Proprietary             | Free app (project paused) | <https://reporterslab.org/factstream/>               | Live fact-check streaming.                                          |
-| Snopes                           | Proprietary editorial   | Free; Snopes+ ~$7.95/mo   | <https://www.snopes.com/>                            | Misconception corpus; verdict labels.                               |
+| Snopes                           | Proprietary editorial   | Free; memberships vary    | <https://www.snopes.com/>                            | Misconception corpus; verdict labels.                               |
 | PolitiFact                       | Proprietary editorial   | Free                      | <https://www.politifact.com/>                        | "Truth-O-Meter" verdict + ClaimReview.                              |
 | OpenFactCheck                    | Apache 2.0              | Free                      | <https://openfactcheck.com/>                         | Unified evaluation harness for LLM factuality.                      |
 
@@ -115,31 +121,31 @@ in `js/src/formalize.js` and `js/src/disambiguation.js`.
 **meta-expression role**: `/uniqueness` and citation/rewording
 suggestions in `js/src/uniqueness.js`.
 
-| Project                                 | License     | Pricing (USD)                                  | URL                            | Concept overlap                              |
-| --------------------------------------- | ----------- | ---------------------------------------------- | ------------------------------ | -------------------------------------------- |
-| Turnitin (Similarity / Feedback Studio) | Proprietary | Institutional, ~$3–10/student/year             | <https://www.turnitin.com/>    | Education plagiarism + AI-writing detection. |
-| iThenticate / Crossref Similarity Check | Proprietary | From $125 per 25k-word manuscript              | <https://www.ithenticate.com/> | Scholarly pre-publication screening.         |
-| Copyscape                               | Proprietary | Free basic; Premium ~$0.03 per 300-word search | <https://www.copyscape.com/>   | Web duplicate detection.                     |
-| Grammarly Premium                       | Proprietary | $12/mo annual / $30/mo monthly                 | <https://www.grammarly.com/>   | Grammar + plagiarism + AI.                   |
-| Quetext                                 | Proprietary | Free ≤500 words; Pro $9.99/mo                  | <https://www.quetext.com/>     | DeepSearch plagiarism.                       |
-| PlagScan                                | Proprietary | From ~$5.99 / 6,000 words                      | <https://www.plagscan.com/>    | Education/enterprise plagiarism.             |
-| Sentence-Transformers / SBERT           | Apache 2.0  | Free                                           | <https://sbert.net/>           | Semantic similarity baseline.                |
+| Project                                 | License     | Pricing (USD)                                                 | URL                            | Concept overlap                              |
+| --------------------------------------- | ----------- | ------------------------------------------------------------- | ------------------------------ | -------------------------------------------- |
+| Turnitin (Similarity / Feedback Studio) | Proprietary | Institutional, ~$3–10/student/year                            | <https://www.turnitin.com/>    | Education plagiarism + AI-writing detection. |
+| iThenticate / Crossref Similarity Check | Proprietary | From $125 per 25k-word manuscript                             | <https://www.ithenticate.com/> | Scholarly pre-publication screening.         |
+| Copyscape                               | Proprietary | Free basic; Premium ~$0.03 per 300-word search                | <https://www.copyscape.com/>   | Web duplicate detection.                     |
+| Grammarly Pro                           | Proprietary | $12/mo annual / $30/mo monthly                                | <https://www.grammarly.com/>   | Grammar + plagiarism + AI.                   |
+| Quetext                                 | Proprietary | Free ≤500 words; Pro $9.99/mo                                 | <https://www.quetext.com/>     | DeepSearch plagiarism.                       |
+| PlagScan                                | Proprietary | Quote/account-based; no current public self-serve price found | <https://www.plagscan.com/>    | Education/enterprise plagiarism.             |
+| Sentence-Transformers / SBERT           | Apache 2.0  | Free                                                          | <https://sbert.net/>           | Semantic similarity baseline.                |
 
 ## 6. AI writing and fact-check assistants
 
 **meta-expression role**: shared territory with general AI chat
 products. Meta-expression intentionally bounds the role of LLMs (R12).
 
-| Project           | License     | Pricing (USD)                                       | URL                              | Concept overlap                                       |
-| ----------------- | ----------- | --------------------------------------------------- | -------------------------------- | ----------------------------------------------------- |
-| Perplexity AI     | Proprietary | Free; Pro $20/mo ($200/yr); Enterprise $40+/seat    | <https://www.perplexity.ai/>     | Citations + answer engine.                            |
-| You.com           | Proprietary | Free; Pro $15/mo; Team $20/seat                     | <https://you.com/>               | Multi-mode AI search.                                 |
-| ChatGPT           | Proprietary | Free; Plus $20/mo; Team $25–$30/seat                | <https://chatgpt.com/>           | Browsing-with-citations mode.                         |
-| Claude            | Proprietary | Free; Pro $20/mo; Team $25/seat                     | <https://claude.ai/>             | Web search + tool use.                                |
-| Microsoft Copilot | Proprietary | Free; Pro $20/mo; M365 Copilot $30/user/mo          | <https://copilot.microsoft.com/> | Bing-backed citations.                                |
-| Elicit            | Proprietary | Free; Plus $12/mo; Pro $49/mo                       | <https://elicit.com/>            | Literature-review automation.                         |
-| Consensus.app     | Proprietary | Free; Premium $8.99/mo (annual) / $11.99/mo monthly | <https://consensus.app/>         | Consensus Meter ≈ `signedConfidence`.                 |
-| Jenni AI          | Proprietary | Free 10/day; Plus $12/mo; Pro $29/mo                | <https://jenni.ai/>              | Academic writing assistant (called out in issue #20). |
+| Project           | License     | Pricing (USD)                                                 | URL                              | Concept overlap                                       |
+| ----------------- | ----------- | ------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------- |
+| Perplexity AI     | Proprietary | Free; Pro $20/mo ($200/yr); Enterprise Pro/Max paid           | <https://www.perplexity.ai/>     | Citations + answer engine.                            |
+| You.com           | Proprietary | Free; Pro $20/mo annual; Max $200/mo annual; APIs usage-based | <https://you.com/>               | Multi-mode AI search.                                 |
+| ChatGPT           | Proprietary | Free; Plus $20/mo; Pro $100–$200/mo; Business $20–$25/seat    | <https://chatgpt.com/>           | Browsing-with-citations mode.                         |
+| Claude            | Proprietary | Free; Pro $20/mo; Max $100–$200/mo; Team paid                 | <https://claude.ai/>             | Web search + tool use.                                |
+| Microsoft Copilot | Proprietary | Free; Pro $20/mo; M365 Copilot Business paid                  | <https://copilot.microsoft.com/> | Bing-backed citations.                                |
+| Elicit            | Proprietary | Free; Plus $10–$12/mo; Pro $42–$49/mo                         | <https://elicit.com/>            | Literature-review automation.                         |
+| Consensus.app     | Proprietary | Free; Pro $10/mo annual / $15/mo monthly                      | <https://consensus.app/>         | Consensus Meter ≈ `signedConfidence`.                 |
+| Jenni AI          | Proprietary | Free 10/day; Plus $12/mo; Pro $29/mo                          | <https://jenni.ai/>              | Academic writing assistant (called out in issue #20). |
 
 ## 7. Links Notation and knowledge representation
 

--- a/docs/COMPARISON-FEATURES.md
+++ b/docs/COMPARISON-FEATURES.md
@@ -1,8 +1,12 @@
 # Feature comparison: meta-expression vs. similar projects
 
-> Last checked: 2026-05-12.
+> Last checked: 2026-05-26.
 > Companion document: [`COMPARISON-CONCEPTS.md`](./COMPARISON-CONCEPTS.md).
-> Source case study: [`docs/case-studies/issue-26/`](./case-studies/issue-26/).
+> Source case studies:
+> [`docs/case-studies/issue-26/`](./case-studies/issue-26/) and
+> [`docs/case-studies/issue-71/`](./case-studies/issue-71/).
+> Missing-feature ledger:
+> [`docs/case-studies/issue-71/MISSING-FEATURES.md`](./case-studies/issue-71/MISSING-FEATURES.md).
 > Issue #20 extension:
 > [`docs/case-studies/issue-20/`](./case-studies/issue-20/).
 
@@ -57,6 +61,8 @@ The matrix below collapses each cluster into the most-cited project
 representative. For a full per-project listing see
 [`COMPARISON-CONCEPTS.md`](./COMPARISON-CONCEPTS.md) and the raw research
 log [`docs/case-studies/issue-26/ONLINE-RESEARCH.md`](./case-studies/issue-26/ONLINE-RESEARCH.md).
+The 2026-05-26 refresh is archived in
+[`docs/case-studies/issue-71/ONLINE-RESEARCH.md`](./case-studies/issue-71/ONLINE-RESEARCH.md).
 
 | Feature                                | Wolfram Alpha             | Wikidata SPARQL         | Coq / Lean / Z3       | Stanford OpenIE           | DBpedia Spotlight     | Turnitin / iThenticate    | SBERT                                     | Perplexity AI           | Consensus.app                          | Wikipedia / ClaimReview | Neo4j / Datomic  | RDF / JSON-LD / PROV-O | LinksPlatform / Doublets |
 | -------------------------------------- | ------------------------- | ----------------------- | --------------------- | ------------------------- | --------------------- | ------------------------- | ----------------------------------------- | ----------------------- | -------------------------------------- | ----------------------- | ---------------- | ---------------------- | ------------------------ |
@@ -150,7 +156,34 @@ The F8 ("evidence") and F9 ("correctness + signed confidence") rows do
   prefilled issue-report state, Links Notation export, or Rust/doublets
   persistence surface.
 
-## 6. How this matrix is maintained
+## 6. Competitor-derived follow-up issues
+
+Canonical ledger: `docs/case-studies/issue-71/MISSING-FEATURES.md`.
+
+Issue #71 turns the refreshed competitor gaps into focused child issues:
+[#87](https://github.com/link-assistant/meta-expression/issues/87) for
+ClaimReview / Schema.org interchange,
+[#88](https://github.com/link-assistant/meta-expression/issues/88) for
+PROV-O / JSON-LD provenance export,
+[#89](https://github.com/link-assistant/meta-expression/issues/89) for
+OpenIE / AMR / SRL formalization inputs,
+[#90](https://github.com/link-assistant/meta-expression/issues/90) for
+document-level originality reporting,
+[#91](https://github.com/link-assistant/meta-expression/issues/91) for
+literature-review evidence workflows,
+[#92](https://github.com/link-assistant/meta-expression/issues/92) for
+SPARQL and graph exports,
+[#93](https://github.com/link-assistant/meta-expression/issues/93) for
+formal proof and solver artifacts, and
+[#94](https://github.com/link-assistant/meta-expression/issues/94) for browser
+and editor assistant surfaces.
+
+Existing sibling issues stay linked to the parity work: #72 executes harvested
+competitor and formal-ai corpora as tests, #73 tracks the formal-ai
+compatibility contract, and #74 keeps generalized algorithms from regressing
+already-supported examples.
+
+## 7. How this matrix is maintained
 
 1. When a new feature lands in meta-expression, add a row to §1 and a
    column-by-column assessment in §2.
@@ -158,8 +191,12 @@ The F8 ("evidence") and F9 ("correctness + signed confidence") rows do
    corresponding cell and bump the `Last checked` date.
 3. When pricing changes, update
    [`COMPARISON-CONCEPTS.md`](./COMPARISON-CONCEPTS.md) and the
-   raw research log
-   [`docs/case-studies/issue-26/ONLINE-RESEARCH.md`](./case-studies/issue-26/ONLINE-RESEARCH.md).
+   current issue-specific raw research log, most recently
+   [`docs/case-studies/issue-71/ONLINE-RESEARCH.md`](./case-studies/issue-71/ONLINE-RESEARCH.md).
+4. When a competitor exposes a shipped feature meta-expression lacks, file a
+   focused child issue and update
+   [`docs/case-studies/issue-71/MISSING-FEATURES.md`](./case-studies/issue-71/MISSING-FEATURES.md).
 
 The [`docs/case-studies/issue-26/`](./case-studies/issue-26/) folder
-records the audit trail per row.
+records the baseline audit trail per row; issue-specific refreshes record the
+current delta.

--- a/docs/case-studies/issue-26/ONLINE-RESEARCH.md
+++ b/docs/case-studies/issue-26/ONLINE-RESEARCH.md
@@ -1,6 +1,9 @@
 # Online research log for issue #26
 
-> Last checked: 2026-05-11.
+> Last checked: 2026-05-26.
+> Baseline captured: 2026-05-11.
+> Latest refresh delta:
+> [`docs/case-studies/issue-71/ONLINE-RESEARCH.md`](../issue-71/ONLINE-RESEARCH.md).
 
 This log archives the public-source data behind
 [`docs/COMPARISON-CONCEPTS.md`](../../COMPARISON-CONCEPTS.md) and
@@ -13,15 +16,15 @@ entry below is a verifiable claim with a URL.
 
 ### A.1 Automated fact checking
 
-| Project                          | License                 | Pricing (USD)           | URL                                                  | Notes                                                                                 |
-| -------------------------------- | ----------------------- | ----------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Google Fact Check Tools API      | Proprietary             | Free, rate-limited      | <https://developers.google.com/fact-check/tools/api> | Returns `ClaimReview` JSON-LD; closest source of structured truth-verdict provenance. |
-| ClaimBuster (UT Arlington)       | Free academic API       | Free with key           | <https://idir.uta.edu/claimbuster/>                  | Returns a check-worthiness score 0..1; KDD'17 paper supplies canonical fixtures.      |
-| Full Fact AI                     | Proprietary partnership | Free for non-profit     | <https://fullfact.ai/>                               | UK political claims; some components open-sourced on GitHub.                          |
-| FactStream (Duke Reporters' Lab) | Proprietary, free app   | Free                    | <https://reporterslab.org/factstream/>               | Successor project is Squash; FactStream is largely paused.                            |
-| Snopes                           | Proprietary editorial   | Free; Snopes+ ~$7.95/mo | <https://www.snopes.com/>                            | Truth/False/Mixture/Unproven ratings; supplies misconception corpus.                  |
-| PolitiFact                       | Proprietary editorial   | Free                    | <https://www.politifact.com/>                        | "Pants on Fire" through "True"; ClaimReview-marked.                                   |
-| OpenFactCheck                    | Apache 2.0              | Free                    | <https://openfactcheck.com/>                         | Unified framework to evaluate LLM factuality.                                         |
+| Project                          | License                 | Pricing (USD)          | URL                                                  | Notes                                                                                 |
+| -------------------------------- | ----------------------- | ---------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Google Fact Check Tools API      | Proprietary             | Free, rate-limited     | <https://developers.google.com/fact-check/tools/api> | Returns `ClaimReview` JSON-LD; closest source of structured truth-verdict provenance. |
+| ClaimBuster (UT Arlington)       | Free academic API       | Free with key          | <https://idir.uta.edu/claimbuster/>                  | Returns a check-worthiness score 0..1; KDD'17 paper supplies canonical fixtures.      |
+| Full Fact AI                     | Proprietary partnership | Free for non-profit    | <https://fullfact.ai/>                               | UK political claims; some components open-sourced on GitHub.                          |
+| FactStream (Duke Reporters' Lab) | Proprietary, free app   | Free                   | <https://reporterslab.org/factstream/>               | Successor project is Squash; FactStream is largely paused.                            |
+| Snopes                           | Proprietary editorial   | Free; memberships vary | <https://www.snopes.com/>                            | Truth/False/Mixture/Unproven ratings; supplies misconception corpus.                  |
+| PolitiFact                       | Proprietary editorial   | Free                   | <https://www.politifact.com/>                        | "Pants on Fire" through "True"; ClaimReview-marked.                                   |
+| OpenFactCheck                    | Apache 2.0              | Free                   | <https://openfactcheck.com/>                         | Unified framework to evaluate LLM factuality.                                         |
 
 ### A.2 Knowledge graphs and reasoning systems
 
@@ -63,28 +66,28 @@ entry below is a verifiable claim with a URL.
 
 ### A.5 Uniqueness / paraphrase
 
-| Project                                 | License     | Pricing (USD)                                  | URL                            | Notes                                    |
-| --------------------------------------- | ----------- | ---------------------------------------------- | ------------------------------ | ---------------------------------------- |
-| Turnitin (Similarity / Feedback Studio) | Proprietary | Institutional, ~$3–10/student/year             | <https://www.turnitin.com/>    | LMS integrations; closed-source.         |
-| iThenticate / Crossref Similarity Check | Proprietary | From $125 per 25k-word manuscript              | <https://www.ithenticate.com/> | Scholarly publishing focus.              |
-| Copyscape                               | Proprietary | Free basic; Premium ~$0.03 per 300-word search | <https://www.copyscape.com/>   | Web-content dup detection.               |
-| Grammarly Premium                       | Proprietary | $12/mo (annual) / $30/mo monthly               | <https://www.grammarly.com/>   | Grammar + plagiarism + AI.               |
-| Quetext                                 | Proprietary | Free 500 words; Pro $9.99/mo                   | <https://www.quetext.com/>     | DeepSearch plagiarism.                   |
-| PlagScan                                | Proprietary | Pay-as-you-go from ~$5.99 / 6,000 words        | <https://www.plagscan.com/>    | Education/enterprise.                    |
-| Sentence-Transformers / SBERT           | Apache 2.0  | Free                                           | <https://sbert.net/>           | Semantic similarity baseline; self-host. |
+| Project                                 | License     | Pricing (USD)                                                 | URL                            | Notes                                    |
+| --------------------------------------- | ----------- | ------------------------------------------------------------- | ------------------------------ | ---------------------------------------- |
+| Turnitin (Similarity / Feedback Studio) | Proprietary | Institutional, ~$3–10/student/year                            | <https://www.turnitin.com/>    | LMS integrations; closed-source.         |
+| iThenticate / Crossref Similarity Check | Proprietary | From $125 per 25k-word manuscript                             | <https://www.ithenticate.com/> | Scholarly publishing focus.              |
+| Copyscape                               | Proprietary | Free basic; Premium ~$0.03 per 300-word search                | <https://www.copyscape.com/>   | Web-content dup detection.               |
+| Grammarly Pro                           | Proprietary | $12/mo (annual) / $30/mo monthly                              | <https://www.grammarly.com/>   | Grammar + plagiarism + AI.               |
+| Quetext                                 | Proprietary | Free 500 words; Pro $9.99/mo                                  | <https://www.quetext.com/>     | DeepSearch plagiarism.                   |
+| PlagScan                                | Proprietary | Quote/account-based; no current public self-serve price found | <https://www.plagscan.com/>    | Education/enterprise.                    |
+| Sentence-Transformers / SBERT           | Apache 2.0  | Free                                                          | <https://sbert.net/>           | Semantic similarity baseline; self-host. |
 
 ### A.6 AI writing and fact-check assistants
 
-| Project           | License     | Pricing (USD)                                          | URL                              | Notes                                    |
-| ----------------- | ----------- | ------------------------------------------------------ | -------------------------------- | ---------------------------------------- |
-| Perplexity AI     | Proprietary | Free; Pro $20/mo ($200/yr); Enterprise $40+/seat       | <https://www.perplexity.ai/>     | Inline citations; closest provenance UX. |
-| You.com           | Proprietary | Free; Pro $15/mo; Team $20/seat                        | <https://you.com/>               | Multiple modes (Genius, Research).       |
-| ChatGPT           | Proprietary | Free; Plus $20/mo; Team $25–$30/seat; Enterprise quote | <https://chatgpt.com/>           | Browsing-with-citations mode.            |
-| Claude            | Proprietary | Free; Pro $20/mo; Team $25/seat; API per-token         | <https://claude.ai/>             | Web search + Computer Use + MCP.         |
-| Microsoft Copilot | Proprietary | Free; Pro $20/mo; M365 Copilot $30/user/mo             | <https://copilot.microsoft.com/> | Bing-backed footnoted citations.         |
-| Elicit            | Proprietary | Free; Plus $12/mo; Pro $49/mo; Enterprise quote        | <https://elicit.com/>            | Lit-review automation.                   |
-| Consensus.app     | Proprietary | Free; Premium $8.99/mo (annual) / $11.99/mo            | <https://consensus.app/>         | Consensus Meter ≈ `signedConfidence`.    |
-| Jenni AI          | Proprietary | Free 10 autocompletes/day; Plus $12/mo; Pro $29/mo     | <https://jenni.ai/>              | Mentioned explicitly in issue #20.       |
+| Project           | License     | Pricing (USD)                                                | URL                              | Notes                                    |
+| ----------------- | ----------- | ------------------------------------------------------------ | -------------------------------- | ---------------------------------------- |
+| Perplexity AI     | Proprietary | Free; Pro $20/mo ($200/yr); Enterprise Pro/Max paid          | <https://www.perplexity.ai/>     | Inline citations; closest provenance UX. |
+| You.com           | Proprietary | Free; Pro $20/mo annual; Max $200/mo annual; API usage-based | <https://you.com/>               | Multiple modes (Genius, Research).       |
+| ChatGPT           | Proprietary | Free; Plus $20/mo; Pro $100–$200/mo; Business $20–$25/seat   | <https://chatgpt.com/>           | Browsing-with-citations mode.            |
+| Claude            | Proprietary | Free; Pro $20/mo; Max $100–$200/mo; Team paid                | <https://claude.ai/>             | Web search + Computer Use + MCP.         |
+| Microsoft Copilot | Proprietary | Free; Pro $20/mo; M365 Copilot Business paid                 | <https://copilot.microsoft.com/> | Bing-backed footnoted citations.         |
+| Elicit            | Proprietary | Free; Plus $10–$12/mo; Pro $42–$49/mo; Enterprise quote      | <https://elicit.com/>            | Lit-review automation.                   |
+| Consensus.app     | Proprietary | Free; Pro $10/mo annual / $15/mo monthly                     | <https://consensus.app/>         | Consensus Meter ≈ `signedConfidence`.    |
+| Jenni AI          | Proprietary | Free 10 autocompletes/day; Plus $12/mo; Pro $29/mo           | <https://jenni.ai/>              | Mentioned explicitly in issue #20.       |
 
 ### A.7 Links Notation / knowledge representation
 
@@ -117,12 +120,12 @@ adapter to PROV-O is tracked in
 
 ## C. Pricing snapshot methodology
 
-All pricing values were captured from publicly accessible vendor pages on
-2026-05-11. Multi-tier products list only the entry consumer tier and
-the cheapest paid tier; enterprise and contact-for-quote tiers are
-noted but not priced. We deliberately avoid implying any tier as the
-"recommended" plan because the comparison docs aim to map _concepts_,
-not endorse products.
+Baseline pricing values were captured from publicly accessible vendor pages on
+2026-05-11 and refreshed for issue #71 on 2026-05-26. Multi-tier products list
+only the entry consumer tier and the cheapest paid tier unless a higher tier is
+material to the comparison; enterprise and contact-for-quote tiers are noted but
+not priced. We deliberately avoid implying any tier as the "recommended" plan
+because the comparison docs aim to map _concepts_, not endorse products.
 
 ## D. Library survey (potential dependencies)
 

--- a/docs/case-studies/issue-71/MISSING-FEATURES.md
+++ b/docs/case-studies/issue-71/MISSING-FEATURES.md
@@ -1,0 +1,33 @@
+# Missing competitor-derived features for issue #71
+
+> Last checked: 2026-05-26.
+> Parent issue: [#71](https://github.com/link-assistant/meta-expression/issues/71).
+> Epic: [#58](https://github.com/link-assistant/meta-expression/issues/58).
+
+This ledger converts the refreshed comparison matrices into focused follow-up
+issues. Each row is a missing feature exposed by one or more competitors but not
+yet shipped as a first-class meta-expression surface.
+
+## Child issue ledger
+
+| Missing feature                         | Competitor signal                                                                                 | Current meta-expression state                                                                   | Child issue                                                                                             |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| ClaimReview / Schema.org interchange    | Google Fact Check Tools API, Schema.org ClaimReview, PolitiFact, Snopes, Full Fact AI             | `/check` exists, but ClaimReview import/export does not.                                        | [#87](https://github.com/link-assistant/meta-expression/issues/87)                                      |
+| PROV-O / JSON-LD provenance export      | RDF, JSON-LD, PROV-O, DBpedia, Wikidata Query Service, Neo4j, Datomic, TerminusDB                 | Evidence is structured and Links-Notation-exportable, but there is no standards export.         | [#88](https://github.com/link-assistant/meta-expression/issues/88)                                      |
+| OpenIE / AMR / SRL formalization inputs | Stanford OpenIE, CoreNLP, spaCy, AllenNLP, AMR, Boxer/C&C, DBpedia Spotlight, BabelNet, TextRazor | Deterministic formalization and Wikidata resolution exist, but no richer NLP provider surface.  | [#89](https://github.com/link-assistant/meta-expression/issues/89)                                      |
+| document-level originality reporting    | Turnitin, iThenticate, Copyscape, Grammarly Pro, Quetext, PlagScan, SBERT                         | `/uniqueness` exists, but report spans, source exclusions, and multi-source reports are narrow. | [#90](https://github.com/link-assistant/meta-expression/issues/90)                                      |
+| literature-review evidence workflows    | Elicit, Consensus.app, Jenni AI, Perplexity, ChatGPT, Claude, Microsoft Copilot                   | Single-claim evidence exists, but paper screening, excerpts, agreement, and exports do not.     | [#91](https://github.com/link-assistant/meta-expression/issues/91)                                      |
+| SPARQL and graph exports                | Wikidata Query Service, DBpedia, YAGO, Neo4j, Datomic, TerminusDB, RDF/OWL, JSON-LD stores        | Selected Wikimedia templates exist, but scoped SPARQL and graph database import/export do not.  | [#92](https://github.com/link-assistant/meta-expression/issues/92)                                      |
+| Proof and solver artifacts              | Rocq/Coq, Lean 4, Isabelle/HOL, Metamath, Wolfram Mathematica, Z3, SWI-Prolog, Souffle            | Exact arithmetic exists, but external proof/solver artifact adapters do not.                    | [#93](https://github.com/link-assistant/meta-expression/issues/93); execution parity stays in [#72][72] |
+| Browser and editor assistant surfaces   | Grammarly, Jenni AI, Microsoft Copilot, Perplexity, You.com, ChatGPT, Claude                      | Web, CLI, service, and library exist, but no editor/browser integration surface.                | [#94](https://github.com/link-assistant/meta-expression/issues/94)                                      |
+
+[72]: https://github.com/link-assistant/meta-expression/issues/72
+
+## Existing linked parity gates
+
+- [#72](https://github.com/link-assistant/meta-expression/issues/72) executes
+  the harvested competitor fixtures and formal-ai corpus as real tests.
+- [#73](https://github.com/link-assistant/meta-expression/issues/73) keeps the
+  formal-ai compatibility contract visible.
+- [#74](https://github.com/link-assistant/meta-expression/issues/74) keeps
+  generalized algorithms from regressing already-supported examples.

--- a/docs/case-studies/issue-71/ONLINE-RESEARCH.md
+++ b/docs/case-studies/issue-71/ONLINE-RESEARCH.md
@@ -1,0 +1,261 @@
+# Online research log for issue #71
+
+> Last checked: 2026-05-26.
+> Baseline:
+> [`docs/case-studies/issue-26/ONLINE-RESEARCH.md`](../issue-26/ONLINE-RESEARCH.md).
+
+This log refreshes the competitor facts behind
+[`docs/COMPARISON-CONCEPTS.md`](../../COMPARISON-CONCEPTS.md) and
+[`docs/COMPARISON-FEATURES.md`](../../COMPARISON-FEATURES.md). It keeps issue
+#26 as the baseline and records the 2026-05-26 delta needed by issue #71.
+
+## Method
+
+- Re-opened the public project or vendor URL for every competitor listed in the
+  comparison docs.
+- Preferred official project pages, vendor pricing pages, standards pages, and
+  project package repositories.
+- Recorded exact prices only when a public page exposed them without login.
+  Quote-only, institutional, or no-longer-public pricing is marked as such.
+- Converted missing competitor capabilities into child issues in
+  [`MISSING-FEATURES.md`](./MISSING-FEATURES.md).
+
+## A. Material changes since issue #26
+
+| Area                       | Refresh finding                                                                                                                                                                          | Doc action                                                                |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| AI assistant pricing       | ChatGPT now needs Plus, Pro, and Business tiers; Claude adds explicit Max tiers; You.com and Perplexity expose higher-end Max/Enterprise tiers.                                          | Updated `COMPARISON-CONCEPTS.md` AI assistant rows.                       |
+| Writing/originality tools  | Grammarly now presents the paid plan as Grammarly Pro; Quetext exposes plagiarism-only and word-bundle pricing; PlagScan no longer surfaced public self-service pricing in this refresh. | Updated uniqueness/pricing rows and kept PlagScan as quote/account-based. |
+| NLP provider pricing       | TextRazor still exposes the free 500-request/day tier and paid Starter/Growth/Pro plans.                                                                                                 | Kept TextRazor as the paid entity-linking SaaS comparison.                |
+| Fact-check interchange     | Google Fact Check Tools API and Schema.org ClaimReview remain the clearest structured fact-check interchange surfaces.                                                                   | Filed ClaimReview parity issue #87.                                       |
+| Linked-data interchange    | RDF, JSON-LD, and PROV-O remain the standards gap next to Links Notation.                                                                                                                | Filed JSON-LD/PROV-O parity issue #88.                                    |
+| Literature-review workflow | Elicit, Consensus.app, and Jenni AI expose paper workflows, confidence/review surfaces, and bibliography/document exports that meta-expression does not ship.                            | Filed literature-review parity issue #91.                                 |
+
+## B. Rechecked competitor roster
+
+### B.1 Automated fact checking
+
+- Google Fact Check Tools API: proprietary Google API; free API-key access;
+  capability remains ClaimReview search plus authorized ClaimReview write/edit
+  workflows. Gap: ClaimReview import/export (#87).
+- ClaimBuster: academic API with key request; pricing remains free/public
+  academic access; capability remains check-worthiness scoring.
+- Full Fact AI: proprietary Full Fact project; public page describes AI-aided
+  fact-checking workflows rather than self-serve pricing. Gap pressure: claim
+  monitoring and editorial review workflows (#87, #91).
+- FactStream: Reporters' Lab project remains a free app/project reference with
+  successor work around live claim monitoring. Gap pressure: streaming claim
+  intake, not an immediate shipped surface.
+- Snopes: proprietary editorial site; articles remain publicly readable and
+  subscriptions/memberships are optional. Gap pressure: verdict corpus and
+  ClaimReview-style fact-check records (#87).
+- PolitiFact: proprietary editorial fact-checking site; public fact checks and
+  Truth-O-Meter labels remain current. Gap pressure: verdict labels and
+  ClaimReview examples (#87).
+- OpenFactCheck: Apache-licensed factuality evaluation framework; public package
+  and paper remain available. Gap pressure: benchmark integration; execution is
+  handled by #72.
+
+### B.2 Knowledge graphs and reasoning systems
+
+- Cyc / ResearchCyc: proprietary, quote-based historical reasoning system;
+  OpenCyc/ResearchCyc remain reference systems rather than adoptable
+  dependencies.
+- Wolfram Alpha: proprietary web/API product; public API tiers still include a
+  free low-volume tier and paid usage above it. Gap pressure: computable facts
+  and curated knowledge, partly addressed by existing exact arithmetic and
+  evidence work.
+- DBpedia: community/open linked-data project; public datasets and SPARQL/linked
+  data access remain available. Gap pressure: generic SPARQL/import/export
+  (#92) and standards export (#88).
+- YAGO: open knowledge-base project; free public datasets remain available. Gap
+  pressure: richer temporal/spatial evidence templates (#92).
+- Wikidata Query Service: free public SPARQL endpoint over CC0 data; already
+  intersects meta-expression live evidence. Gap pressure: scoped SPARQL export
+  and bounded query execution (#92).
+- Mycroft AI / OVOS: open voice-assistant ecosystem; kept as adjacent
+  conversational-agent context, but not a direct reasoning gap.
+
+### B.3 Formal verification and logic kernels
+
+- Rocq/Coq: LGPL proof assistant; current public site identifies Rocq as the
+  successor name and latest prover release. Gap pressure: external proof
+  artifacts (#93).
+- Lean 4: Apache-licensed theorem prover/programming language; free and active.
+  Gap pressure: proof-snippet import/export (#93).
+- Isabelle/HOL: BSD-style theorem prover; free and active. Gap pressure:
+  theorem/proof artifact references (#93).
+- Metamath: public-domain/CC0 proof database and verifier ecosystem; free. Gap
+  pressure: proof database references (#93).
+- Wolfram Mathematica: proprietary symbolic computation product with public home
+  and student pricing; gap pressure is symbolic computation artifacts (#93).
+- Z3: MIT-licensed SMT solver; free. Gap pressure: SMT-LIB adapter and solver
+  result provenance (#93).
+- SWI-Prolog: BSD-licensed logic programming system; free. Gap pressure: logic
+  fact/rule adapter (#93).
+- Souffle: UPL-licensed Datalog system; free. Gap pressure: Datalog rule/result
+  adapter (#93).
+
+### B.4 Natural language to logic, entity linking, and AMR
+
+- spaCy: MIT-licensed NLP library; free. Gap pressure: provider interface for
+  NER and dependency parses (#89).
+- Stanford CoreNLP: GPL v3 with commercial licensing; free for GPL-compatible
+  use. Gap pressure: relation triples and OpenIE-backed candidates (#89).
+- AllenNLP: Apache-licensed research library in maintenance mode; free. Gap
+  pressure: semantic-role and AMR-style provider fixtures (#89).
+- Abstract Meaning Representation: mixed ecosystem with paid LDC datasets and
+  free tools/papers. Gap pressure: sentence-level semantic graphs (#89).
+- Boxer / C&C: academic research tools; no current commercial self-serve pricing
+  surfaced. Gap pressure: compositional semantics fixtures (#89).
+- BabelNet / Babelfy: academic-free/commercial-quote sense-disambiguation
+  service. Gap pressure: multilingual entity/sense provider interface (#89).
+- DBpedia Spotlight: Apache-licensed entity-linking service. Gap pressure:
+  external entity-link candidates (#89).
+- TextRazor: proprietary SaaS; free 500 requests/day, paid Starter/Growth/Pro
+  tiers begin at $200/month. Gap pressure: paid entity and relation extraction
+  provider (#89).
+- Stanford OpenIE: GPL v3 relation extraction tool; free. Gap pressure:
+  schema-free relation triples with confidence (#89).
+
+### B.5 Uniqueness and paraphrase
+
+- Turnitin Similarity / Feedback Studio: proprietary institutional product;
+  pricing remains institutional/quote or contract based. Gap pressure:
+  document-level reports with matched sources (#90).
+- iThenticate / Crossref Similarity Check: proprietary; public individual
+  packages include $125 single-manuscript credits and $300 multiple-manuscript
+  credits. Gap pressure: manuscript-scale reports (#90).
+- Copyscape: proprietary duplicate-content service; Premium/API pricing remains
+  per search and word length. Gap pressure: source URL matches and report spans
+  (#90).
+- Grammarly Pro: proprietary writing assistant; public paid plan is now
+  Grammarly Pro, with annual and monthly pricing. Gap pressure: editor
+  integration plus plagiarism/originality reporting (#90, #94).
+- Quetext: proprietary plagiarism and AI-content detection service; public
+  pricing includes plagiarism-only and word-bundle tiers. Gap pressure:
+  downloadable originality reports and word-budgeted document checks (#90).
+- PlagScan: proprietary plagiarism service; active public pages remain, but no
+  current self-serve pricing was found during this refresh. Treat as
+  quote/account-based until a public pricing page is restored. Gap pressure:
+  education/enterprise reports (#90).
+- Sentence-Transformers / SBERT: Apache-licensed semantic similarity library;
+  free. Gap pressure: paraphrase/similarity embeddings for `/uniqueness` (#90).
+
+### B.6 AI writing and fact-check assistants
+
+- Perplexity: proprietary answer engine; public pricing includes Free, Pro
+  ($20/month or $200/year), Enterprise Pro, and Enterprise Max tiers. Gap
+  pressure: cited-answer UX, source collections, and research workflows (#91,
+  #94).
+- You.com: proprietary answer/search platform; current public page exposes chat
+  plans plus usage-priced search/content/research APIs. Gap pressure: embedded
+  AI-search surfaces and cited research workflows (#91, #94).
+- ChatGPT: proprietary OpenAI chat product; public pages list Free, Plus, Pro,
+  Business, and Enterprise tiers. Gap pressure: browser/app surfaces, connectors,
+  and cited research workflows (#91, #94).
+- Claude: proprietary Anthropic chat product; Pro remains $20/month and Max
+  tiers are $100/month and $200/month. Gap pressure: long-context research,
+  tool-use workflows, and editor/app integrations (#91, #94).
+- Microsoft Copilot: proprietary Microsoft assistant; Copilot Pro remains
+  $20/user/month and Microsoft 365 Copilot Business has public per-user pricing.
+  Gap pressure: document/editor embedding (#94).
+- Elicit: proprietary research assistant; public pricing exposes Basic, Plus,
+  Pro, Team, and Enterprise; API access requires Pro or above. Gap pressure:
+  paper metadata, reports, excerpts, and BibTeX/RIS/CSV exports (#91).
+- Consensus.app: proprietary literature-search assistant; public help now calls
+  the paid tier Consensus Pro and lists annual/monthly pricing. Gap pressure:
+  literature agreement scores and paper snapshots (#91).
+- Jenni AI: proprietary academic writing assistant; public docs list Free, Plus,
+  and Pro plans. Gap pressure: writing-review workflow, citations, document
+  export, and editor surface (#91, #94).
+
+### B.7 Links Notation and knowledge representation
+
+- RDF / OWL: W3C standards; free and royalty-free. Gap pressure: RDF export and
+  ontology-compatible projections (#88, #92).
+- JSON-LD: W3C linked-data JSON serialization; free. Gap pressure: JSON-LD
+  evidence/result export (#88).
+- PROV-O / PROV-JSON-LD: W3C provenance ontology; free. Gap pressure: explicit
+  evidence provenance export (#88).
+- LinksPlatform / Doublets: open links infrastructure; remains the closest
+  native storage substrate. Current Rust/doublets work addresses part of this
+  area; standards interop is still #88/#92.
+- Datomic: proprietary, time-aware datalog database with free Pro and
+  usage-based Cloud posture. Gap pressure: immutable query/import/export (#92).
+- Neo4j: community/enterprise graph database; public Aura and enterprise pricing
+  remain outside the current meta-expression storage surface. Gap pressure:
+  Cypher/graph-store export (#92).
+- TerminusDB: AGPL graph database with SaaS tier. Gap pressure: versioned
+  knowledge-store import/export (#92).
+
+## C. Child issue mapping
+
+| Gap family                  | Child issue |
+| --------------------------- | ----------- |
+| ClaimReview fact checks     | #87         |
+| JSON-LD / PROV-O provenance | #88         |
+| OpenIE / AMR / SRL inputs   | #89         |
+| Originality reports         | #90         |
+| Literature-review evidence  | #91         |
+| SPARQL and graph exports    | #92         |
+| Proof and solver artifacts  | #93         |
+| Browser/editor surfaces     | #94         |
+
+## D. References
+
+- <https://developers.google.com/fact-check/tools/api>
+- <https://schema.org/ClaimReview>
+- <https://idir.uta.edu/claimbuster-dev/api/request/key/>
+- <https://fullfact.org/full-fact-ai/>
+- <https://reporterslab.org/factstream/>
+- <https://www.snopes.com/terms-and-conditions/>
+- <https://www.politifact.com/>
+- <https://pypi.org/project/openfactcheck/0.3.2/>
+- <https://products.wolframalpha.com/api/pricing>
+- <https://www.wolfram.com/mathematica/>
+- <https://www.dbpedia.org/>
+- <https://yago-knowledge.org/>
+- <https://query.wikidata.org/>
+- <https://rocq-prover.org/>
+- <https://lean-lang.org/>
+- <https://isabelle.in.tum.de/>
+- <https://us.metamath.org/>
+- <https://github.com/Z3Prover/z3>
+- <https://www.swi-prolog.org/>
+- <https://souffle-lang.github.io/>
+- <https://spacy.io/>
+- <https://stanfordnlp.github.io/CoreNLP/>
+- <https://allenai.org/allennlp>
+- <https://amr.isi.edu/>
+- <https://www.let.rug.nl/bos/comsem/boxer.html>
+- <https://babelnet.org/>
+- <https://www.dbpedia-spotlight.org/>
+- <https://www.textrazor.com/plans>
+- <https://nlp.stanford.edu/software/openie.html>
+- <https://www.turnitin.com/>
+- <https://www.ithenticate.com/products>
+- <https://www.copyscape.com/premium.php>
+- <https://www.grammarly.com/plans>
+- <https://www.quetext.com/pricing>
+- <https://www.plagscan.com/en/terms-of-service-and-data-protection>
+- <https://sbert.net/>
+- <https://www.perplexity.ai/enterprise/pricing>
+- <https://you.com/platform/upgrade>
+- <https://openai.com/chatgpt/pricing/>
+- <https://openai.com/business/chatgpt-pricing/>
+- <https://support.claude.com/en/articles/8325606-what-is-claude-pro>
+- <https://support.anthropic.com/en/articles/11049744-how-much-does-the-max-plan-cost>
+- <https://www.microsoft.com/en-us/store/b/copilotpro>
+- <https://www.microsoft.com/en-us/microsoft-365/copilot/pricing>
+- <https://orion.elicit.com/pricing>
+- <https://docs.elicit.com/>
+- <https://help.consensus.app/en/articles/11408820-what-do-you-get-with-premium>
+- <https://docs.jenni.ai/docs/account/plans-and-billing/>
+- <https://www.w3.org/RDF/>
+- <https://json-ld.org/>
+- <https://www.w3.org/TR/prov-o/>
+- <https://github.com/linksplatform>
+- <https://www.datomic.com/>
+- <https://neo4j.com/pricing/>
+- <https://terminusdb.com/>

--- a/docs/case-studies/issue-71/README.md
+++ b/docs/case-studies/issue-71/README.md
@@ -1,0 +1,29 @@
+# Issue #71: competitor parity refresh
+
+> Parent: [#58](https://github.com/link-assistant/meta-expression/issues/58).
+> Pull request: [#86](https://github.com/link-assistant/meta-expression/pull/86).
+> Last checked: 2026-05-26.
+
+Issue #71 refreshes the competitor comparison matrices that were created in
+issue #26 and extended in issue #20. The work is documentation-focused: it
+re-checks public competitor pricing, license, and capability surfaces, updates
+the comparison dates, and files one focused follow-up issue per missing
+competitor-derived feature.
+
+## Artifacts
+
+- [`ONLINE-RESEARCH.md`](./ONLINE-RESEARCH.md) records the 2026-05-26 public
+  source refresh.
+- [`MISSING-FEATURES.md`](./MISSING-FEATURES.md) maps each gap to a child
+  issue.
+- [`REQUIREMENTS.md`](./REQUIREMENTS.md) captures the acceptance criteria for
+  this refresh.
+- [`SOLUTION-PLAN.md`](./SOLUTION-PLAN.md) records the implementation plan.
+
+## Outcome
+
+- `docs/COMPARISON-CONCEPTS.md` and `docs/COMPARISON-FEATURES.md` are re-dated
+  to 2026-05-26.
+- The feature matrix now links to the child-issue ledger.
+- Follow-up issues #87 through #94 track the missing features found by the
+  refresh.

--- a/docs/case-studies/issue-71/REQUIREMENTS.md
+++ b/docs/case-studies/issue-71/REQUIREMENTS.md
@@ -1,0 +1,38 @@
+# Requirements for issue #71
+
+> Last checked: 2026-05-26.
+
+## R71.1 Re-check competitor facts
+
+Every competitor listed in `docs/COMPARISON-CONCEPTS.md` must be re-checked
+against public project or vendor pages for:
+
+- license or ownership posture,
+- free, paid, quote-based, or unavailable pricing,
+- capability overlap with meta-expression.
+
+## R71.2 Re-date comparison matrices
+
+`docs/COMPARISON-CONCEPTS.md` and `docs/COMPARISON-FEATURES.md` must both carry
+`Last checked: 2026-05-26`.
+
+## R71.3 Preserve an audit trail
+
+The refresh must have an issue-specific research log at
+`docs/case-studies/issue-71/ONLINE-RESEARCH.md`. The original issue #26 log
+remains the baseline.
+
+## R71.4 File child issues for missing features
+
+Each competitor-derived missing feature must be tracked by a focused GitHub
+issue and linked from `docs/case-studies/issue-71/MISSING-FEATURES.md`.
+
+## R71.5 Keep the matrix maintainable
+
+The feature matrix must link to the missing-feature ledger so future updates can
+distinguish shipped meta-expression advantages from parity gaps.
+
+## R71.6 Add a documentation regression
+
+A unit test must fail when the comparison docs are stale, the issue-71 research
+log is missing, or the missing-feature ledger is removed.

--- a/docs/case-studies/issue-71/SOLUTION-PLAN.md
+++ b/docs/case-studies/issue-71/SOLUTION-PLAN.md
@@ -1,0 +1,34 @@
+# Solution plan for issue #71
+
+> Last checked: 2026-05-26.
+
+## 1. Reproduce the stale-doc failure
+
+Add a documentation unit test that expects:
+
+- issue-71 research and missing-feature files,
+- 2026-05-26 `Last checked` dates in both comparison docs,
+- a feature-matrix section for competitor-derived follow-up issues.
+
+## 2. Refresh public competitor facts
+
+Use the issue #26 matrix as the baseline, re-open the public vendor and project
+URLs, and record only the changes or confirmations that matter for parity.
+
+## 3. Update comparison docs
+
+Re-date `COMPARISON-CONCEPTS.md` and `COMPARISON-FEATURES.md`, update pricing
+rows that changed or could no longer be verified publicly, and link the new
+research log.
+
+## 4. File missing-feature issues
+
+Translate the refreshed gaps into focused child issues. Reuse existing sibling
+issues when they already own a gap, and avoid filing generic umbrella issues
+when the competitor pressure points to a specific surface.
+
+## 5. Verify
+
+Run the documentation test, then the relevant repository checks for the files
+touched by this PR. The PR is complete only when the test protects the refreshed
+dates and ledger.

--- a/js/tests/unit/documentation.test.js
+++ b/js/tests/unit/documentation.test.js
@@ -30,4 +30,32 @@ describe('vision documentation', () => {
       expect(docs.toLowerCase().includes(phrase)).toBe(false);
     }
   });
+
+  it('keeps competitor parity research current and linked to follow-up issues', () => {
+    const concepts = readFileSync('docs/COMPARISON-CONCEPTS.md', 'utf8');
+    const features = readFileSync('docs/COMPARISON-FEATURES.md', 'utf8');
+    const researchPath = 'docs/case-studies/issue-71/ONLINE-RESEARCH.md';
+    const missingFeaturesPath =
+      'docs/case-studies/issue-71/MISSING-FEATURES.md';
+
+    expect(existsSync(researchPath)).toBe(true);
+    expect(existsSync(missingFeaturesPath)).toBe(true);
+    expect(concepts.includes('> Last checked: 2026-05-26.')).toBe(true);
+    expect(features.includes('> Last checked: 2026-05-26.')).toBe(true);
+    expect(features.includes('Competitor-derived follow-up issues')).toBe(true);
+    expect(concepts.includes(researchPath)).toBe(true);
+    expect(features.includes(missingFeaturesPath)).toBe(true);
+
+    const missingFeatures = readFileSync(missingFeaturesPath, 'utf8');
+    for (const expectedGap of [
+      'ClaimReview / Schema.org',
+      'PROV-O / JSON-LD',
+      'OpenIE / AMR',
+      'document-level originality',
+      'literature-review evidence',
+      'SPARQL and graph exports',
+    ]) {
+      expect(missingFeatures.includes(expectedGap)).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
Fixes #71.

## Summary
- Rechecked the competitor comparison matrices on 2026-05-26 and refreshed pricing/license/capability notes where public sources changed or no longer exposed self-serve pricing.
- Added the issue #71 research log and missing-feature ledger under `docs/case-studies/issue-71/`.
- Filed focused child issues for each competitor-derived gap: #87, #88, #89, #90, #91, #92, #93, and #94.
- Added a documentation regression test that fails if the refreshed dates, research log, or missing-feature ledger are removed.
- Added the required patch changeset for the documentation refresh.

## Verification
- `npm run test:unit`
- `npm run check`
- `npm test`
- `git diff --check`
- `GITHUB_BASE_REF=main GITHUB_BASE_SHA=$(git rev-parse origin/main) GITHUB_HEAD_SHA=$(git rev-parse HEAD) node scripts/validate-changeset.mjs`

## Notes
- This is documentation-only; no UI screenshots are applicable.