### PR TITLE
docs: Track formal-ai compatibility contract

### DIFF
--- a/.changeset/issue-73-formal-ai-contract.md
+++ b/.changeset/issue-73-formal-ai-contract.md
@@ -1,0 +1,6 @@
+---
+'meta-expression': patch
+---
+
+Document the formal-ai compatibility contract across the library, CLI, service,
+web, and Rust/WASM surfaces.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-26T00:15:43.690Z for PR creation at branch issue-71-213699cb7a07 for issue https://github.com/link-assistant/meta-expression/issues/71
 # Updated: 2026-05-26T04:14:24.216Z
-# Updated: 2026-05-26T04:35:56.033Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-26T00:15:43.690Z for PR creation at branch issue-71-213699cb7a07 for issue https://github.com/link-assistant/meta-expression/issues/71
 # Updated: 2026-05-26T04:14:24.216Z
+# Updated: 2026-05-26T04:35:56.033Z

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ formalization reference at
 [`docs/FORMALIZE.md`](docs/FORMALIZE.md) (regenerated from JSDoc with
 `npm run docs:formalize`).
 
+The downstream formal-ai foundation surface is tracked in
+[`docs/FORMAL_AI_COMPATIBILITY.md`](docs/FORMAL_AI_COMPATIBILITY.md): the
+OpenAI-shaped, Lino-native, WASM-buildable contract across library, CLI,
+microservice, web, and Rust surfaces.
+
 ## Library
 
 ```js

--- a/docs/FORMAL_AI_COMPATIBILITY.md
+++ b/docs/FORMAL_AI_COMPATIBILITY.md
@@ -1,0 +1,164 @@
+# Formal AI Compatibility Contract
+
+> Last checked: 2026-05-26.
+> Downstream: [formal-ai](https://github.com/link-assistant/formal-ai)
+> formal-ai v0.123.0,
+> commit `39530ef2e71f787561f9252b72032eb81e329c3e`.
+
+This contract defines what meta-expression keeps stable so formal-ai can use it
+as a symbolic foundation while meta-expression remains useful as a standalone
+library, CLI, service, web prototype, and Rust/WASM core.
+
+formal-ai exposes OpenAI-shaped Chat Completions and Responses interfaces. The
+meta-expression side of that contract is lower level: it must keep
+formalization, transformation, naturalization, reasoning, probability, evidence,
+and Links Notation exchange predictable enough that formal-ai can wrap them in
+its assistant surfaces without adding hidden neural inference or hidden state.
+
+## Contract Principles
+
+- **OpenAI-shaped boundary**: downstream assistant APIs may speak
+  `/v1/chat/completions`, `/v1/responses`, roles, messages, responses, models,
+  status, and token usage, but meta-expression primitives stay deterministic
+  and symbolic.
+- **Lino-native exchange**: every durable semantic artifact must be representable
+  as Links Notation or as data that can regenerate Links Notation without
+  losing link ids, references, provenance, roles, versions, or source spans.
+- **WASM-buildable core**: Rust functionality intended for browser or formal-ai
+  reuse must remain compatible with the `wasm-bindgen` package and the
+  JavaScript `loadWasmCore()` wrapper.
+- **Additive evolution**: new fields may be added, but existing JSON,
+  TypeScript, Links Notation, CLI, service, web, and Rust/WASM fields should not
+  be removed or renamed without a tracked breaking-change issue.
+- **Explicit unknowns**: unsupported text, incomplete formal expressions, and
+  missing evidence stay partial or unknown. LLM suggestions, user preferences,
+  and source weights must be explicit inputs, not hidden truth sources.
+
+## Surface Matrix
+
+| Surface      | Entry points                                                                                                                                  | Input contract                                                                                                    | Output contract                                                                                                                                              |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Library      | `analyzeStatement`, `formalizeTextWith`, `translateTextWith`, `naturalizeExpressionWith`, `deformalizeExpressionWith`, `rewriteLinksNotation` | Human text, selected interpretations, transformation rules, belief profiles, source options, optional RML hook    | Structured result, confidence/correctness/probability, evidence, CST/AST metadata, Links Network records, Markdown/HTML/Links Notation where applicable      |
+| CLI          | `analyze`, `formalize`, `translate`, `check`, `fact-check`, `uniqueness`                                                                      | Positional or `--input` text, `--format`, `--live`, language, source, override, article, score, and profile flags | JSON for machine use, Links Notation for Lino-native exchange, Markdown/HTML for rendered surfaces, nonzero exit on command/runtime errors                   |
+| Microservice | `GET`/`POST /analyze`, `/formalize`, `/translate`, `/check`, `/fact-check`, `/uniqueness`, plus `/health`                                     | Query parameters or JSON bodies matching the CLI/library options                                                  | HTTP JSON by default; route `format` options expose Links Notation, Markdown, or HTML without changing the underlying semantic records                       |
+| Static web   | Analyse, Compare, Check, Uniqueness, Formalize, Translate, Preferences                                                                        | Browser text input, selected interpretation, local belief/preference controls, source/link-target controls        | Same semantic payloads as the library surfaced as UI state, report URLs, local storage state, worker results, Links Notation, Markdown, HTML, CST, and steps |
+| Rust         | `meta-expression-core`, `wasm-bindgen` package, `loadWasmCore()` wrapper, Rust unit/integration fixtures                                      | UTF-8 text, typed Rust structs, deterministic transformation and metadata helpers                                 | WASM-safe JSON/string values, selected analysis fields, Links Notation, semantic translation helpers, parser metadata, cache/batch-planning helpers          |
+
+## Operation Contract
+
+### formalize
+
+`formalizeTextWith()` is the canonical JavaScript formalization entry point.
+It accepts text plus source, override, context, and hook options, and returns a
+CST rich enough for downstream tools to regenerate Markdown and Links Notation.
+The CST must keep phrase ids, source spans, selected entity ids, source URLs,
+candidate information, contexts, parser metadata, linguistic fragments, and
+relation records stable as additive data.
+
+Rust mirrors the deterministic metadata subset through
+`extract_linguistic_metadata()` and related WASM-safe helpers. Rust and
+JavaScript do not need byte-identical internal structures, but overlapping
+public fields must preserve the same meaning.
+
+### transform
+
+Transformation starts as ordered text/object hook phases and
+Links Notation rewrite helpers. The supported hook shapes are function rules,
+object rules with `apply`, declarative text replacements, and declarative
+object assignments. A rule that changes a value must be traceable through a
+step record with phase, rule id, and before/after summary.
+
+The long-term target is a parser-backed Links Notation rewrite engine. Until
+that lands, existing hook names and the `rewriteLinksNotation` /
+`simplifyLinksNotation` helpers remain compatibility anchors.
+
+### naturalize
+
+Naturalization and deformalization are aliases for the same public behavior.
+JavaScript exposes `naturalizeExpressionWith()` and
+`deformalizeExpressionWith()`; translation results expose both
+`naturalization` and `deformalization` views. Rust exposes the matching
+deterministic deformalization alias for semantic translations.
+
+Naturalized output must keep text, CST, semantic links, and Links Notation in
+sync after transformation hooks run.
+
+### reason
+
+Reasoning covers interpretation selection, formalization-level description,
+exact computable evaluation, evidence-scored real-world claims, formal
+reasoning summaries, dependency records, and relative-meta-logic adapter
+mapping. Computable expressions may return exact truth or numeric answers.
+Real-world claims must return bounded evidence estimates with visible support,
+refutation, source, retrieval time, and calculation inputs.
+
+Unsupported reasoning stays explicit through unknowns, refinement suggestions,
+or partial-formalization output.
+
+### translate
+
+Translation is a consumer of formalization plus transformation plus
+naturalization. It must keep source phrase ids, target meaning ids, semantic
+links, questions for unresolved parts, trace steps, and sentence-level rendered
+output. Formal AI prompt translation support in English, Russian, Hindi, and
+Chinese is covered by the upstream corpus fixture and parity tests.
+
+### probability and evidence
+
+Probability calculations must name their strategy, input values, truth range,
+valence, deterministic/bounded status, and evidence items. Legacy
+`result.confidence` and `result.rawBalance` stay available while newer
+`correctness`, `signedConfidence`, `probability`, and `calculation` fields are
+used for richer clients.
+
+## Release Tracking
+
+When formal-ai publishes a new release, update this file if the shared
+contract changes:
+
+1. Record the latest formal-ai tag, commit, commit date, and release date.
+2. Regenerate or verify `js/tests/fixtures/formal-ai-test-corpus.json` when
+   upstream test identities changed.
+3. Run the formal-ai corpus and parity tests that map upstream cases to local
+   assertions or explicit skip reasons.
+4. Confirm that library, CLI, service, web, and Rust/WASM surfaces still expose
+   the operation contract above.
+5. File a child issue for any newly unsupported downstream requirement rather
+   than hiding it in a skip reason.
+
+The latest checked downstream release is:
+
+| Repository                 | Release    | Commit                                     | Release date         |
+| -------------------------- | ---------- | ------------------------------------------ | -------------------- |
+| `link-assistant/formal-ai` | `v0.123.0` | `39530ef2e71f787561f9252b72032eb81e329c3e` | 2026-05-26T00:50:47Z |
+
+## Verification Anchors
+
+- `js/tests/fixtures/formal-ai-test-corpus.json` pins the upstream formal-ai
+  corpus at `v0.123.0`.
+- `js/tests/integration/issue-54-formal-ai-corpus.test.js` verifies the pinned
+  upstream test identities and Formal AI prompt translation behavior.
+- `js/tests/integration/issue-72-parity.test.js` requires each upstream test
+  identity to have either local coverage or an explicit skip reason.
+- `js/tests/integration/issue-61-wasm.test.js` verifies the JavaScript wrapper
+  over the Rust WASM package.
+- `rust/tests/unit/issue54_formal_ai.rs`,
+  `rust/tests/unit/issue70_reasoning_metadata.rs`, and
+  `rust/tests/integration/issue61_wasm_surface.rs` cover the Rust side of the
+  shared compatibility surface.
+
+## Deferred Or App-Specific Areas
+
+The following formal-ai behaviors are intentionally not promised by
+meta-expression itself:
+
+- assistant-specific dialogue memory and app shell behavior;
+- Telegram bot transport behavior;
+- Docker runtime and formal-ai release workflow behavior;
+- proof-assistant UX beyond the formal reasoning and relative-meta-logic
+  adapter surfaces;
+- browser-only formal-ai UI state that is not expressible through shared
+  symbolic artifacts.
+
+When any of those areas needs a shared primitive, the primitive should be added
+to this contract before formal-ai relies on it.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -7,6 +7,9 @@ prototype. It consolidates:
 - [Issue #5](https://github.com/link-assistant/meta-expression/issues/5)
 - [Issue #16](https://github.com/link-assistant/meta-expression/issues/16)
 - [Issue #18](https://github.com/link-assistant/meta-expression/issues/18)
+- [Issue #54](https://github.com/link-assistant/meta-expression/issues/54)
+- [Issue #58](https://github.com/link-assistant/meta-expression/issues/58)
+- [Issue #73](https://github.com/link-assistant/meta-expression/issues/73)
 - [PR #6 feedback](https://github.com/link-assistant/meta-expression/pull/6#issuecomment-4322346610)
 
 ## Terminology
@@ -70,6 +73,15 @@ boundary.
 | R47 | Keep translation tests fact-based and reproducible.           | MVP   | Issue #16 tests mock Wikidata search/entity responses and issue #52 tests cover the full reported seven-sentence EN→RU→EN flow in JS and Rust.                                                             | Add snapshot-backed integration tests for more multilingual examples.                                           |
 | R48 | Translate each sentence and whole text, not only words.       | MVP   | `/translate` returns sentence records and builds final text from sentence-level renderings with tested transformation rules; issue #52 covers exact full-text translation and back translation.            | Replace the narrow rule table with parser-backed Links Notation transformations.                                |
 | R49 | Show formalization and translation steps.                     | MVP   | Translate results include `formalization` and `steps`; the web page shows formalized input and collapsed step details.                                                                                     | Add user-editable rule inspection and replay once persistence is available.                                     |
+| R57 | Be a dependable foundation for formal-ai and a tool itself.   | Next  | [`FORMAL_AI_COMPATIBILITY.md`](./FORMAL_AI_COMPATIBILITY.md) tracks the OpenAI-shaped, Lino-native, WASM-buildable contract across library, CLI, microservice, static web, and Rust surfaces.              | Keep formalize/transform/naturalize/reason behavior stable as formal-ai releases change.                        |
+
+## Formal-AI Foundation Contract
+
+The formal-ai compatibility contract is maintained in
+[`docs/FORMAL_AI_COMPATIBILITY.md`](./FORMAL_AI_COMPATIBILITY.md). It records
+the latest checked formal-ai release, the shared inputs and outputs for each
+public surface, and the operation contract for `formalize`, `transform`,
+`naturalize`, `reason`, translation, probability, and evidence.
 
 ## Concrete Acceptance Examples
 

--- a/docs/case-studies/issue-73/README.md
+++ b/docs/case-studies/issue-73/README.md
@@ -1,0 +1,57 @@
+# Issue 73 Case Study
+
+Issue: <https://github.com/link-assistant/meta-expression/issues/73>
+Pull request: <https://github.com/link-assistant/meta-expression/pull/97>
+
+## Summary
+
+Issue #73 tracks the OpenAI-shaped, Lino-native compatibility contract that
+lets `link-assistant/formal-ai` depend on meta-expression without treating
+prototype behavior as accidental API. The implemented artifact is
+[`../../FORMAL_AI_COMPATIBILITY.md`](../../FORMAL_AI_COMPATIBILITY.md).
+
+## Upstream Pin
+
+The latest formal-ai release checked for this contract was:
+
+```text
+v0.123.0
+39530ef2e71f787561f9252b72032eb81e329c3e
+2026-05-26T00:48:52Z
+chore: release v0.123.0
+```
+
+GitHub reported the release as `[Rust] 0.123.0`, published at
+`2026-05-26T00:50:47Z`.
+
+## Contract Coverage
+
+The contract records:
+
+- contract principles for OpenAI-shaped boundaries, Lino-native exchange,
+  WASM-buildable Rust/WASM surfaces, additive evolution, and explicit unknowns;
+- a surface matrix for Library, CLI, Microservice, Static web, and Rust;
+- operation contracts for formalize, transform, naturalize, reason, translate,
+  probability, and evidence;
+- the release-tracking workflow for future formal-ai releases;
+- verification anchors in JavaScript and Rust tests;
+- formal-ai app-specific areas that are intentionally outside the shared
+  meta-expression contract.
+
+## Reproducer
+
+`js/tests/unit/documentation.test.js` now requires the contract document, the
+latest formal-ai release pin, the operation names, the five public surfaces, and
+README/requirements cross-links. Before this PR, that test failed because
+`docs/FORMAL_AI_COMPATIBILITY.md` did not exist.
+
+## Verification
+
+Focused check:
+
+```bash
+node --test js/tests/unit/documentation.test.js
+```
+
+Broader checks are recorded in the pull request body after final local
+verification.

--- a/js/tests/unit/documentation.test.js
+++ b/js/tests/unit/documentation.test.js
@@ -58,4 +58,36 @@ describe('vision documentation', () => {
       expect(missingFeatures.includes(expectedGap)).toBe(true);
     }
   });
+
+  it('tracks the formal-ai compatibility contract as a first-class doc', () => {
+    const contractPath = 'docs/FORMAL_AI_COMPATIBILITY.md';
+
+    expect(existsSync(contractPath)).toBe(true);
+
+    const contract = readFileSync(contractPath, 'utf8');
+    const readme = readFileSync('README.md', 'utf8');
+    const requirements = readFileSync('docs/REQUIREMENTS.md', 'utf8');
+
+    for (const expected of [
+      'formal-ai v0.123.0',
+      '39530ef2e71f787561f9252b72032eb81e329c3e',
+      'OpenAI-shaped',
+      'Lino-native',
+      'WASM-buildable',
+      'formalize',
+      'transform',
+      'naturalize',
+      'reason',
+      'Library',
+      'CLI',
+      'Microservice',
+      'Static web',
+      'Rust',
+    ]) {
+      expect(contract.includes(expected)).toBe(true);
+    }
+
+    expect(readme.includes(contractPath)).toBe(true);
+    expect(requirements.includes(contractPath)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- Add `docs/FORMAL_AI_COMPATIBILITY.md` as the formal-ai foundation contract for the OpenAI-shaped, Lino-native, WASM-buildable surface.
- Link the contract from `README.md` and `docs/REQUIREMENTS.md`, including the R57 requirement row for issue #73.
- Add an issue #73 case study and a documentation unit test that keeps the contract, current formal-ai release pin, operation names, surface names, and cross-links from regressing.
- Add a patch changeset for the documented contract update.

Fixes #73.

## Reproduce

Before this change, the new documentation test failed because `docs/FORMAL_AI_COMPATIBILITY.md` did not exist. The passing test now verifies the contract is present, pinned to formal-ai `v0.123.0` / `39530ef2e71f787561f9252b72032eb81e329c3e`, covers the expected operations and public surfaces, and is linked from README and requirements.

## Testing

- `node --test js/tests/unit/documentation.test.js`
- `npm run check`
- `npm test`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo test --workspace --all-targets --all-features --verbose`
- `cargo test --workspace --doc --verbose`
