### PR TITLE
Add ClaimReview JSON-LD import and export

### DIFF
--- a/.changeset/issue-87-claim-review.md
+++ b/.changeset/issue-87-claim-review.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': minor
+---
+
+Add Schema.org ClaimReview JSON-LD import and export for fact-check records.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-26T00:15:43.690Z for PR creation at branch issue-71-213699cb7a07 for issue https://github.com/link-assistant/meta-expression/issues/71
-# Updated: 2026-05-26T04:14:24.216Z
-# Updated: 2026-05-26T05:09:57.648Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-26T00:15:43.690Z for PR creation at branch issue-71-213699cb7a07 for issue https://github.com/link-assistant/meta-expression/issues/71
 # Updated: 2026-05-26T04:14:24.216Z
+# Updated: 2026-05-26T05:09:57.648Z

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Core exports:
 - `checkText(input, options)` detects statements in longer text, analyzes each
   statement, and returns red-to-green correctness coloring as JSON, HTML,
   Markdown, and Links Notation.
+- `importClaimReviewJsonLd(input)` and `exportClaimReviewJsonLd(result)` import
+  and export Schema.org ClaimReview JSON-LD for fact-check interchange.
 - `searchTextUniqueness(input, options)` searches detected statements across
   public web and scholarly APIs, returning existing-likelihood scores,
   citation/rewording suggestions, source matches, HTML, Markdown, and Links
@@ -102,6 +104,7 @@ node js/src/cli.js analyze --input "Paris is the capital of France" --live
 node js/src/cli.js formalize --input "Hawaii is a state." --format markdown
 node js/src/cli.js translate --input "Hawaii is a state." --to ru --format markdown
 node js/src/cli.js check --input "Earth orbits the Sun. 1 + 1 = 1." --format html
+node js/src/cli.js check --input "Earth orbits the Sun." --format claim-review
 node js/src/cli.js fact-check --input "Paris is the capital of France." --live
 node js/src/cli.js uniqueness --input "Earth orbits the Sun." --format markdown
 ```
@@ -114,6 +117,7 @@ curl "http://127.0.0.1:3000/analyze?input=1%20%2B%201%20%3D%202"
 curl "http://127.0.0.1:3000/analyze?input=Earth%20orbits%20the%20Sun&format=links"
 curl "http://127.0.0.1:3000/translate?input=Hawaii%20is%20a%20state.&to=ru&format=markdown"
 curl "http://127.0.0.1:3000/check?input=Earth%20orbits%20the%20Sun.%201%20%2B%201%20%3D%201.&format=html"
+curl "http://127.0.0.1:3000/check?input=Earth%20orbits%20the%20Sun.&format=claim-review"
 curl "http://127.0.0.1:3000/uniqueness?input=Earth%20orbits%20the%20Sun.&format=markdown"
 ```
 
@@ -127,7 +131,7 @@ Routes:
 - `POST /formalize` with `{ "input": "...", "format": "json" }`
 - `GET /translate?input=...&from=en&to=ru&format=json|links|markdown|html`
 - `POST /translate` with `{ "input": "...", "targetLanguage": "ru" }`
-- `GET /check?input=...&format=json|links|markdown|html`
+- `GET /check?input=...&format=json|links|markdown|html|claim-review`
 - `POST /check` with `{ "input": "...", "live": true }`
 - `GET /fact-check?input=...` and `POST /fact-check` as aliases for
   `/check`

--- a/js/src/claim-review.js
+++ b/js/src/claim-review.js
@@ -1,0 +1,519 @@
+const schemaContext = 'https://schema.org';
+const schemaClaimReview = 'ClaimReview';
+const defaultFactCheckUrl = 'https://github.com/link-assistant/meta-expression';
+
+export function parseClaimReviewJsonLd(input, options = {}) {
+  return importClaimReviewJsonLd(input, options);
+}
+
+export function importClaimReviewJsonLd(input, options = {}) {
+  const jsonLd = parseJsonLdInput(input);
+  const review = findSchemaNode(jsonLd, schemaClaimReview);
+  if (!review) {
+    throw new Error('ClaimReview JSON-LD record not found.');
+  }
+
+  const claimText = claimTextFromReview(review);
+  if (!claimText) {
+    throw new Error('ClaimReview record is missing claimReviewed text.');
+  }
+
+  const verdict = verdictFromReview(review.reviewRating);
+  const source = sourceFromReview(review);
+  const retrievedAt = timestampFrom(
+    options.retrievedAt ?? options.now?.() ?? source.publishedAt ?? new Date()
+  );
+  const provenance = {
+    sourceType: 'claim-review',
+    sourceUrl: source.url,
+    retrievedAt,
+    schemaContext: contextFromReview(review),
+    schemaType: schemaClaimReview,
+    sourceExampleUrl: options.sourceExampleUrl ?? null,
+  };
+  const evidence = evidenceFromClaimReview({
+    claimText,
+    verdict,
+    source,
+    provenance,
+    review,
+  });
+
+  return {
+    status: 'imported',
+    format: 'schema.org/ClaimReview',
+    claim: {
+      text: claimText,
+      itemReviewed: review.itemReviewed ?? null,
+    },
+    verdict,
+    source,
+    provenance,
+    evidence,
+    evidenceItems: [evidence],
+    jsonLd: review,
+  };
+}
+
+export function exportClaimReviewJsonLd(input, options = {}) {
+  const statement = selectCheckedStatement(input, options);
+  const claimReviewed = statementText(statement);
+  if (!claimReviewed) {
+    throw new Error('Cannot export ClaimReview without a checked statement.');
+  }
+
+  const correctness = statementCorrectness(statement);
+  const rating = ratingFromCorrectness(correctness);
+  const evidenceUrl = primaryEvidenceUrl(statement);
+  const sourceUrl =
+    options.url ??
+    options.factCheckUrl ??
+    options.sourceUrl ??
+    evidenceUrl ??
+    defaultFactCheckUrl;
+  const retrievedAt = timestampFrom(
+    options.retrievedAt ?? options.now?.() ?? primaryRetrievedAt(statement)
+  );
+  const citations = uniqueStrings([options.sourceUrl, evidenceUrl]).filter(
+    (url) => url && url !== sourceUrl
+  );
+
+  const jsonLd = {
+    '@context': schemaContext,
+    '@type': schemaClaimReview,
+    url: sourceUrl,
+    claimReviewed,
+    itemReviewed: {
+      '@type': 'Claim',
+      name: claimReviewed,
+    },
+    author: organization(
+      options.author ?? options.authorName ?? 'meta-expression'
+    ),
+    datePublished: datePart(retrievedAt),
+    sdDatePublished: retrievedAt,
+    reviewRating: {
+      '@type': 'Rating',
+      ratingValue: rating.ratingValue,
+      bestRating: rating.bestRating,
+      worstRating: rating.worstRating,
+      alternateName: rating.label,
+    },
+  };
+
+  if (citations.length === 1) {
+    jsonLd.citation = citations[0];
+  } else if (citations.length > 1) {
+    jsonLd.citation = citations;
+  }
+
+  return jsonLd;
+}
+
+function parseJsonLdInput(input) {
+  if (typeof input !== 'string') {
+    return input;
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('ClaimReview JSON-LD input is empty.');
+  }
+  if (trimmed.startsWith('<')) {
+    return parseJsonLdScript(trimmed);
+  }
+  return JSON.parse(trimmed);
+}
+
+function parseJsonLdScript(html) {
+  const scripts = [
+    ...html.matchAll(
+      /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/giu
+    ),
+  ];
+  if (scripts.length === 0) {
+    throw new Error('No application/ld+json script tag found.');
+  }
+  return scripts.map((match) => JSON.parse(decodeHtml(match[1].trim())));
+}
+
+function findSchemaNode(value, typeName) {
+  const stack = [value];
+  const seen = new Set();
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item || typeof item !== 'object' || seen.has(item)) {
+      continue;
+    }
+    seen.add(item);
+    if (hasSchemaType(item, typeName)) {
+      return item;
+    }
+    for (const child of Object.values(item)) {
+      if (child && typeof child === 'object') {
+        stack.push(child);
+      }
+    }
+  }
+  return null;
+}
+
+function hasSchemaType(node, expected) {
+  const types = Array.isArray(node['@type']) ? node['@type'] : [node['@type']];
+  return types.some((type) => schemaTypeName(type) === expected);
+}
+
+function schemaTypeName(value) {
+  const text = stringValue(value);
+  return text ? text.split(/[/:#]/u).pop() : '';
+}
+
+function claimTextFromReview(review) {
+  return (
+    stringValue(review.claimReviewed) ||
+    stringValue(review.itemReviewed?.name) ||
+    stringValue(review.itemReviewed?.description)
+  );
+}
+
+function verdictFromReview(reviewRating) {
+  const rating = firstObject(reviewRating) ?? {};
+  const ratingValue = numberValue(rating.ratingValue);
+  const bestRating = numberValue(rating.bestRating) ?? 5;
+  const worstRating = numberValue(rating.worstRating) ?? 1;
+  const label =
+    stringValue(rating.alternateName) ||
+    stringValue(rating.name) ||
+    labelFromCorrectness(
+      correctnessFromRating(ratingValue, bestRating, worstRating)
+    );
+  const correctness =
+    correctnessFromRating(ratingValue, bestRating, worstRating) ??
+    correctnessFromLabel(label);
+  const polarity =
+    correctness === null || correctness >= 0.5 ? 'support' : 'refute';
+
+  return {
+    label,
+    ratingValue,
+    bestRating,
+    worstRating,
+    correctness,
+    polarity,
+  };
+}
+
+function sourceFromReview(review) {
+  const itemReviewed = firstObject(review.itemReviewed);
+  const appearance = firstObject(itemReviewed?.appearance);
+  return {
+    url: firstString([review.url, review.mainEntityOfPage?.url, review['@id']]),
+    author: entitySummary(review.author ?? review.publisher),
+    publishedAt: stringValue(review.datePublished) || null,
+    modifiedAt: stringValue(review.dateModified) || null,
+    claimSource: claimSourceFromReview(itemReviewed, appearance),
+  };
+}
+
+function claimSourceFromReview(itemReviewed, appearance) {
+  return {
+    author: entitySummary(itemReviewed?.author ?? appearance?.author),
+    url: firstString([
+      itemReviewed?.url,
+      itemReviewed?.sameAs,
+      appearance?.url,
+    ]),
+    publishedAt: firstString([
+      itemReviewed?.datePublished,
+      appearance?.datePublished,
+    ]),
+    headline: stringValue(appearance?.headline) || null,
+  };
+}
+
+function evidenceFromClaimReview({
+  claimText,
+  verdict,
+  source,
+  provenance,
+  review,
+}) {
+  const ratingText = verdict.label || 'Unrated';
+  return {
+    key: normalizeClaimKey(claimText),
+    polarity: verdict.polarity,
+    weight: evidenceWeight(verdict),
+    sourceType: 'claim-review',
+    situation: 'schema-org-claim-review',
+    sourceUrl: source.url,
+    retrievedAt: provenance.retrievedAt,
+    claim: `ClaimReview rated "${claimText}" as "${ratingText}".`,
+    identifiers: {
+      schemaType: schemaClaimReview,
+      ratingValue: stringFromNullable(verdict.ratingValue),
+      bestRating: stringFromNullable(verdict.bestRating),
+      worstRating: stringFromNullable(verdict.worstRating),
+    },
+    context: {
+      verdict,
+      source,
+      provenance,
+      jsonLd: review,
+    },
+  };
+}
+
+function selectCheckedStatement(input, options) {
+  if (input?.status === 'checked' && Array.isArray(input.statements)) {
+    const index = Number.isInteger(options.statementIndex)
+      ? options.statementIndex
+      : 0;
+    return input.statements[index] ?? null;
+  }
+  return input;
+}
+
+function statementText(statement) {
+  return (
+    stringValue(statement?.text) ||
+    stringValue(statement?.analysisInput) ||
+    stringValue(statement?.statement?.value?.text)
+  );
+}
+
+function statementCorrectness(statement) {
+  return firstNormalizedNumber([
+    statement?.correctness,
+    statement?.analysis?.result?.correctness,
+    statement?.result?.correctness,
+    statement?.analysis?.result?.confidence,
+    statement?.result?.confidence,
+  ]);
+}
+
+function primaryEvidenceUrl(statement) {
+  return stringValue(primaryEvidence(statement)?.sourceUrl);
+}
+
+function primaryRetrievedAt(statement) {
+  return stringValue(primaryEvidence(statement)?.retrievedAt) || new Date();
+}
+
+function primaryEvidence(statement) {
+  const result = statement?.analysis?.result ?? statement?.result;
+  const evidence = [
+    ...(result?.supportingEvidence ?? []),
+    ...(result?.refutingEvidence ?? []),
+  ];
+  return evidence.find((item) => item?.sourceUrl) ?? evidence[0] ?? null;
+}
+
+function ratingFromCorrectness(correctness) {
+  if (correctness === null) {
+    return {
+      ratingValue: 3,
+      bestRating: 5,
+      worstRating: 1,
+      label: 'Unverified',
+    };
+  }
+  const ratingValue = Math.round(1 + clamp(correctness, 0, 1) * 4);
+  return {
+    ratingValue,
+    bestRating: 5,
+    worstRating: 1,
+    label: ratingLabel(ratingValue),
+  };
+}
+
+function ratingLabel(value) {
+  switch (value) {
+    case 1:
+      return 'False';
+    case 2:
+      return 'Mostly false';
+    case 3:
+      return 'Half true';
+    case 4:
+      return 'Mostly true';
+    case 5:
+      return 'True';
+    default:
+      return 'Unverified';
+  }
+}
+
+function labelFromCorrectness(correctness) {
+  if (correctness === null) {
+    return 'Unverified';
+  }
+  return ratingLabel(Math.round(1 + clamp(correctness, 0, 1) * 4));
+}
+
+function correctnessFromRating(value, best, worst) {
+  if (value === null || best === worst) {
+    return null;
+  }
+  return clamp((value - worst) / (best - worst), 0, 1);
+}
+
+function correctnessFromLabel(label) {
+  const normalized = stringValue(label).toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.includes('mostly true')) {
+    return 0.75;
+  }
+  if (normalized.includes('half') || normalized.includes('mixed')) {
+    return 0.5;
+  }
+  if (
+    normalized.includes('mostly false') ||
+    normalized.includes('misleading')
+  ) {
+    return 0.25;
+  }
+  if (normalized.includes('false') || normalized.includes('pants on fire')) {
+    return 0;
+  }
+  if (normalized.includes('true') || normalized.includes('correct')) {
+    return 1;
+  }
+  return null;
+}
+
+function evidenceWeight(verdict) {
+  if (verdict.correctness === null) {
+    return 1;
+  }
+  return verdict.polarity === 'refute'
+    ? clamp(1 - verdict.correctness, 0, 1)
+    : clamp(verdict.correctness, 0, 1);
+}
+
+function entitySummary(entity) {
+  if (typeof entity === 'string') {
+    return {
+      type: null,
+      name: entity,
+      url: null,
+    };
+  }
+  const item = firstObject(entity);
+  if (!item) {
+    return null;
+  }
+  return {
+    type: schemaTypeName(item['@type']) || null,
+    name: stringValue(item.name) || null,
+    url: stringValue(item.url) || stringValue(item.sameAs) || null,
+  };
+}
+
+function firstObject(value) {
+  const item = Array.isArray(value) ? value.find(Boolean) : value;
+  return item && typeof item === 'object' ? item : null;
+}
+
+function contextFromReview(review) {
+  return stringValue(review['@context']) || schemaContext;
+}
+
+function organization(value) {
+  if (value && typeof value === 'object') {
+    return value;
+  }
+  return {
+    '@type': 'Organization',
+    name: String(value ?? 'meta-expression'),
+  };
+}
+
+function stringValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value).trim();
+  }
+  if (Array.isArray(value)) {
+    return stringValue(value.find((item) => stringValue(item)));
+  }
+  return '';
+}
+
+function firstString(values) {
+  for (const value of values) {
+    const text = stringValue(value);
+    if (text) {
+      return text;
+    }
+  }
+  return null;
+}
+
+function numberValue(value) {
+  const parsed = Number(stringValue(value));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function firstNormalizedNumber(values) {
+  for (const value of values) {
+    const parsed = normalizedNumber(value);
+    if (parsed !== null) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function normalizedNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? clamp(value, 0, 1)
+    : null;
+}
+
+function timestampFrom(value) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const raw = String(value ?? '').trim();
+  if (!raw) {
+    return new Date().toISOString();
+  }
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? raw : parsed.toISOString();
+}
+
+function datePart(value) {
+  return String(value).slice(0, 10);
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.map(stringValue).filter(Boolean))];
+}
+
+function stringFromNullable(value) {
+  return value === null || value === undefined ? '' : String(value);
+}
+
+function normalizeClaimKey(value) {
+  return String(value ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
+    .trim();
+}
+
+function decodeHtml(value) {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -13,6 +13,7 @@ import {
 import { formalizeTextWith, FORMALIZE_LINK_TARGETS } from './formalize.js';
 import { translateTextWith } from './translate.js';
 import { checkText, checkTextWithLiveEvidence } from './check.js';
+import { exportClaimReviewJsonLd } from './claim-review.js';
 import { searchTextUniqueness } from './uniqueness.js';
 import { parseSourceSpec } from './formalize-sources.js';
 import { loadRepoOverrides, loadUserOverrides } from './formalize-overrides.js';
@@ -87,6 +88,12 @@ export function parseCliArguments(args) {
     },
     '--score': () => {
       applyEvidenceScore(options.evidenceScoring, nextValue());
+    },
+    '--source': () => {
+      options.sourceUrl = nextValue();
+    },
+    '--source-url': () => {
+      options.sourceUrl = nextValue();
     },
     '--profile': () => {
       options.profileFile = nextValue();
@@ -242,6 +249,11 @@ function configureCliYargs({ yargs, getenv }) {
       type: 'string',
       default: getenv('SCORE', ''),
     })
+    .option('source-url', {
+      alias: 'source',
+      type: 'string',
+      default: getenv('SOURCE_URL', ''),
+    })
     .option('profile', {
       type: 'string',
       default: getenv('PROFILE', ''),
@@ -311,6 +323,11 @@ function createCliOptions(config) {
     options,
     'profileFile',
     firstPresent(config.profile, config.beliefProfile, config.preferenceProfile)
+  );
+  assignStringOption(
+    options,
+    'sourceUrl',
+    firstPresent(config.sourceUrl, config.source)
   );
   if (config.help === true) {
     options.command = 'help';
@@ -771,6 +788,18 @@ function emitCliAnalysis(options, output, analysis) {
 }
 
 function emitCheckResult(options, output, result) {
+  if (isClaimReviewFormat(options.format)) {
+    output.log(
+      JSON.stringify(
+        exportClaimReviewJsonLd(result, {
+          sourceUrl: options.sourceUrl,
+        }),
+        null,
+        2
+      )
+    );
+    return 0;
+  }
   if (options.format === 'links' || options.format === 'lino') {
     output.log(result.linksNotation);
     return 0;
@@ -806,6 +835,10 @@ function emitUniquenessResult(options, output, result) {
 
 function isCheckCommand(command) {
   return command === 'check' || command === 'fact-check';
+}
+
+function isClaimReviewFormat(format) {
+  return format === 'claim-review' || format === 'claimreview';
 }
 
 function isUniquenessCommand(command) {
@@ -849,7 +882,7 @@ Commands:
 
 Options:
   -i, --input <text>             Statement text
-  -f, --format <json|links|markdown|html>
+  -f, --format <json|links|markdown|html|claim-review>
   -s, --select <index>           Interpretation index (analyze), default 0
   --live                         analyze: resolve through Wikimedia APIs
   --target <wikipedia|wikidata|local>
@@ -872,6 +905,8 @@ Options:
   --match-threshold <0..1>       translation-quality: token coverage threshold
   --score <situation=probability>
                                  check/fact-check: override evidence scoring
+  --source, --source-url <url>    check/fact-check: source URL for ClaimReview
+                                 exports
   -h, --help                     Show this help`;
 }
 

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1585,6 +1585,59 @@ export interface CheckResult {
   linksNotation: string;
 }
 
+export interface ClaimReviewVerdict {
+  label: string;
+  ratingValue: number | null;
+  bestRating: number;
+  worstRating: number;
+  correctness: number | null;
+  polarity: EvidenceItem['polarity'];
+}
+
+export interface ClaimReviewImportResult {
+  status: 'imported';
+  format: 'schema.org/ClaimReview';
+  claim: {
+    text: string;
+    itemReviewed: unknown;
+  };
+  verdict: ClaimReviewVerdict;
+  source: {
+    url: string | null;
+    author: {
+      type: string | null;
+      name: string | null;
+      url: string | null;
+    } | null;
+    publishedAt: string | null;
+    modifiedAt: string | null;
+    claimSource: Record<string, unknown>;
+  };
+  provenance: {
+    sourceType: 'claim-review';
+    sourceUrl: string | null;
+    retrievedAt: string;
+    schemaContext: string;
+    schemaType: 'ClaimReview';
+    sourceExampleUrl: string | null;
+  };
+  evidence: EvidenceItem;
+  evidenceItems: EvidenceItem[];
+  jsonLd: Record<string, unknown>;
+}
+
+export interface ClaimReviewOptions {
+  retrievedAt?: string | number | Date;
+  now?: () => string | number | Date;
+  sourceExampleUrl?: string;
+  sourceUrl?: string;
+  factCheckUrl?: string;
+  url?: string;
+  author?: Record<string, unknown>;
+  authorName?: string;
+  statementIndex?: number;
+}
+
 export type UniquenessSuggestedAction =
   | 'cite-or-quote'
   | 'review-matches'
@@ -1712,6 +1765,21 @@ export declare function checkTextWithLiveEvidence(
   input: string,
   options?: AnalysisOptions & { locale?: string }
 ): Promise<CheckResult>;
+
+export declare function parseClaimReviewJsonLd(
+  input: string | Record<string, unknown> | unknown[],
+  options?: ClaimReviewOptions
+): ClaimReviewImportResult;
+
+export declare function importClaimReviewJsonLd(
+  input: string | Record<string, unknown> | unknown[],
+  options?: ClaimReviewOptions
+): ClaimReviewImportResult;
+
+export declare function exportClaimReviewJsonLd(
+  input: CheckResult | CheckStatement | StatementAnalysis,
+  options?: ClaimReviewOptions
+): Record<string, unknown>;
 
 export declare function searchTextUniqueness(
   input: string,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -101,6 +101,11 @@ export {
 } from './translation-quality.js';
 export { checkText, checkTextWithLiveEvidence } from './check.js';
 export {
+  exportClaimReviewJsonLd,
+  importClaimReviewJsonLd,
+  parseClaimReviewJsonLd,
+} from './claim-review.js';
+export {
   createCrossrefUniquenessSource,
   createDefaultUniquenessSources,
   createDuckDuckGoUniquenessSource,

--- a/js/src/server.js
+++ b/js/src/server.js
@@ -9,6 +9,7 @@ import {
 import { formalizeTextWith, FORMALIZE_LINK_TARGETS } from './formalize.js';
 import { translateTextWith } from './translate.js';
 import { checkText, checkTextWithLiveEvidence } from './check.js';
+import { exportClaimReviewJsonLd } from './claim-review.js';
 import { searchTextUniqueness } from './uniqueness.js';
 import { parseSourceSpec } from './formalize-sources.js';
 import { loadRepoOverrides, loadUserOverrides } from './formalize-overrides.js';
@@ -228,6 +229,8 @@ function checkParamsFromSearch(url) {
     format: url.searchParams.get('format') ?? 'json',
     live: url.searchParams.get('live') === 'true',
     evidenceScoring: evidenceScoringFromSearch(url),
+    sourceUrl:
+      url.searchParams.get('sourceUrl') ?? url.searchParams.get('source') ?? '',
   };
 }
 
@@ -238,6 +241,7 @@ function checkParamsFromPayload(payload) {
     live: payload.live === true,
     evidenceScoring: payload.evidenceScoring,
     preferenceProfile: payload.preferenceProfile,
+    sourceUrl: payload.sourceUrl ?? payload.source ?? '',
   };
 }
 
@@ -426,7 +430,9 @@ async function sendCheck(response, params, ctx) {
   const result = params.live
     ? await checkTextWithLiveEvidence(params.input, options)
     : checkText(params.input, options);
-  emitCheckResponse(response, params.format, result);
+  emitCheckResponse(response, params.format, result, {
+    sourceUrl: params.sourceUrl,
+  });
 }
 
 async function sendUniqueness(response, params) {
@@ -555,7 +561,17 @@ function emitNaturalizeResponse(response, format, payload) {
   return 0;
 }
 
-function emitCheckResponse(response, format, payload) {
+function emitCheckResponse(response, format, payload, options = {}) {
+  if (isClaimReviewFormat(format)) {
+    sendJson(
+      response,
+      200,
+      exportClaimReviewJsonLd(payload, {
+        sourceUrl: options.sourceUrl,
+      })
+    );
+    return 0;
+  }
   if (format === 'links' || format === 'lino') {
     response.writeHead(200, {
       'content-type': 'text/plain; charset=utf-8',
@@ -579,6 +595,10 @@ function emitCheckResponse(response, format, payload) {
   }
   sendJson(response, 200, payload);
   return 0;
+}
+
+function isClaimReviewFormat(format) {
+  return format === 'claim-review' || format === 'claimreview';
 }
 
 function emitUniquenessResponse(response, format, payload) {

--- a/js/tests/fixtures/claim-review/google-world-flat.json
+++ b/js/tests/fixtures/claim-review/google-world-flat.json
@@ -1,0 +1,49 @@
+{
+  "source": "https://developers.google.com/search/docs/appearance/structured-data/factcheck",
+  "retrievedAt": "2026-05-26T00:00:00.000Z",
+  "jsonLd": {
+    "@context": "https://schema.org",
+    "@type": "ClaimReview",
+    "url": "https://example.com/news/science/worldisflat.html",
+    "claimReviewed": "The world is flat",
+    "itemReviewed": {
+      "@type": "Claim",
+      "author": {
+        "@type": "Organization",
+        "name": "Square World Society",
+        "sameAs": "https://example.flatworlders.com/we-know-that-the-world-is-flat"
+      },
+      "datePublished": "2024-06-20",
+      "appearance": {
+        "@type": "OpinionNewsArticle",
+        "url": "https://example.com/news/a122121",
+        "headline": "Square Earth - Flat earthers for the Internet age",
+        "datePublished": "2024-06-22",
+        "author": {
+          "@type": "Person",
+          "name": "T. Tellar"
+        },
+        "image": "https://example.com/photos/1x1/photo.jpg",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Skeptical News",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://example.com/logo.jpg"
+          }
+        }
+      }
+    },
+    "author": {
+      "@type": "Organization",
+      "name": "Example.com science watch"
+    },
+    "reviewRating": {
+      "@type": "Rating",
+      "ratingValue": 1,
+      "bestRating": 5,
+      "worstRating": 1,
+      "alternateName": "False"
+    }
+  }
+}

--- a/js/tests/integration/issue-87-claim-review.test.js
+++ b/js/tests/integration/issue-87-claim-review.test.js
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'test-anywhere';
+import {
+  checkText,
+  exportClaimReviewJsonLd,
+  importClaimReviewJsonLd,
+  parseClaimReviewJsonLd,
+} from '../../src/index.js';
+import { runCliAsync } from '../../src/cli.js';
+import { createMetaExpressionServer } from '../../src/server.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL('../fixtures/claim-review/google-world-flat.json', import.meta.url),
+    'utf8'
+  )
+);
+
+describe('issue 87 - ClaimReview fact-check interchange', () => {
+  it('imports a public ClaimReview JSON-LD example into evidence, verdict, source, and provenance fields', () => {
+    const imported = importClaimReviewJsonLd(fixture.jsonLd, {
+      retrievedAt: fixture.retrievedAt,
+      sourceExampleUrl: fixture.source,
+    });
+
+    expect(imported.status).toBe('imported');
+    expect(imported.format).toBe('schema.org/ClaimReview');
+    expect(imported.claim.text).toBe('The world is flat');
+    expect(imported.verdict.label).toBe('False');
+    expect(imported.verdict.correctness).toBe(0);
+    expect(imported.source.url).toBe(
+      'https://example.com/news/science/worldisflat.html'
+    );
+    expect(imported.source.author.name).toBe('Example.com science watch');
+    expect(imported.provenance.retrievedAt).toBe(fixture.retrievedAt);
+    expect(imported.provenance.sourceExampleUrl).toBe(fixture.source);
+    expect(imported.evidence.polarity).toBe('refute');
+    expect(imported.evidence.sourceType).toBe('claim-review');
+    expect(imported.evidence.situation).toBe('schema-org-claim-review');
+    expect(imported.evidence.sourceUrl).toBe(imported.source.url);
+    expect(imported.evidence.retrievedAt).toBe(fixture.retrievedAt);
+    expect(imported.evidence.claim).toContain('False');
+  });
+
+  it('parses ClaimReview JSON-LD from an HTML script tag', () => {
+    const html = `<script type="application/ld+json">${JSON.stringify(
+      fixture.jsonLd
+    )}</script>`;
+    const imported = parseClaimReviewJsonLd(html, {
+      retrievedAt: fixture.retrievedAt,
+    });
+
+    expect(imported.claim.text).toBe('The world is flat');
+    expect(imported.verdict.ratingValue).toBe(1);
+  });
+
+  it('exports a checked statement as ClaimReview JSON-LD with claim, rating, source URL, and retrieval timestamp', () => {
+    const checked = checkText('Earth orbits the Sun.');
+    const jsonLd = exportClaimReviewJsonLd(checked, {
+      authorName: 'meta-expression tests',
+      sourceUrl: 'https://example.org/fact-checks/earth-orbits-sun',
+      retrievedAt: '2026-05-26T12:00:00.000Z',
+    });
+    const roundTrip = importClaimReviewJsonLd(jsonLd, {
+      retrievedAt: '2026-05-26T12:00:00.000Z',
+    });
+
+    expect(jsonLd['@context']).toBe('https://schema.org');
+    expect(jsonLd['@type']).toBe('ClaimReview');
+    expect(jsonLd.claimReviewed).toBe('Earth orbits the Sun.');
+    expect(jsonLd.url).toBe('https://example.org/fact-checks/earth-orbits-sun');
+    expect(jsonLd.sdDatePublished).toBe('2026-05-26T12:00:00.000Z');
+    expect(jsonLd.reviewRating['@type']).toBe('Rating');
+    expect(jsonLd.reviewRating.ratingValue).toBe(4);
+    expect(jsonLd.reviewRating.alternateName).toBe('Mostly true');
+    expect(roundTrip.verdict.label).toBe('Mostly true');
+    expect(roundTrip.evidence.polarity).toBe('support');
+  });
+
+  it('keeps plain text /check behavior unchanged', () => {
+    const result = checkText('Earth orbits the Sun. 1 + 1 = 1.');
+
+    expect(result.status).toBe('checked');
+    expect(result.statements.map((statement) => statement.text)).toEqual([
+      'Earth orbits the Sun.',
+      '1 + 1 = 1.',
+    ]);
+    expect(result.summary.correct).toBe(1);
+    expect(result.summary.wrong).toBe(1);
+    expect(result.markdown).toContain('Earth orbits the Sun.');
+    expect(result.linksNotation).toContain('check');
+  });
+
+  it('supports ClaimReview JSON-LD as a /check export format in the CLI', async () => {
+    const output = {
+      logs: [],
+      errors: [],
+      log(value) {
+        this.logs.push(value);
+      },
+      error(value) {
+        this.errors.push(value);
+      },
+    };
+    const exitCode = await runCliAsync(
+      [
+        'check',
+        '--input',
+        '1 + 1 = 1.',
+        '--format',
+        'claim-review',
+        '--source',
+        'https://example.org/fact-checks/arithmetic',
+      ],
+      output
+    );
+    const jsonLd = JSON.parse(output.logs[0]);
+
+    expect(exitCode).toBe(0);
+    expect(jsonLd['@type']).toBe('ClaimReview');
+    expect(jsonLd.claimReviewed).toBe('1 + 1 = 1.');
+    expect(jsonLd.reviewRating.alternateName).toBe('False');
+    expect(jsonLd.url).toBe('https://example.org/fact-checks/arithmetic');
+  });
+
+  it('serves ClaimReview JSON-LD from HTTP /check while keeping default JSON check output', async () => {
+    const started = await startServer();
+    try {
+      const base = `http://127.0.0.1:${started.port}`;
+      const claimReviewResponse = await fetch(
+        `${base}/check?input=${encodeURIComponent(
+          'Earth orbits the Sun.'
+        )}&format=claim-review&source=${encodeURIComponent(
+          'https://example.org/fact-checks/http-earth-orbits-sun'
+        )}`
+      );
+      const defaultResponse = await fetch(
+        `${base}/check?input=${encodeURIComponent('Earth orbits the Sun.')}`
+      );
+      const claimReview = await claimReviewResponse.json();
+      const defaultPayload = await defaultResponse.json();
+
+      expect(claimReviewResponse.status).toBe(200);
+      expect(claimReview['@type']).toBe('ClaimReview');
+      expect(claimReview.url).toBe(
+        'https://example.org/fact-checks/http-earth-orbits-sun'
+      );
+      expect(defaultPayload.status).toBe('checked');
+      expect(defaultPayload.statements[0].text).toBe('Earth orbits the Sun.');
+    } finally {
+      await stopServer(started.server);
+    }
+  });
+});
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const server = createMetaExpressionServer({
+      cacheRoot: '.cache/issue-87-test',
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}


### PR DESCRIPTION
## Summary
- Add Schema.org ClaimReview JSON-LD import into normalized claim, verdict, source, provenance, and meta-expression evidence fields.
- Add ClaimReview JSON-LD export for checked statements, including reviewed claim, rating, source URL, and retrieval timestamp.
- Wire `format=claim-review` through CLI and HTTP `/check` while keeping default plain-text `/check` output unchanged.
- Add a public Google Search Central ClaimReview example fixture and a minor changeset.

Fixes #87

## Reproduce
- Before this change, importing or exporting ClaimReview JSON-LD was not available from the library, CLI, or `/check` service format.
- The new regression test covers JSON-LD object import, HTML `application/ld+json` parsing, checked-statement export, CLI export, HTTP export, and unchanged default `/check` JSON behavior.

## Tests
- `node --test js/tests/integration/issue-87-claim-review.test.js`
- `npm test`
- `npm run check`
- `cargo test --workspace`
- `cargo fmt --all -- --check`