### PR TITLE
feat: Export evidence provenance as JSON-LD and PROV-O

### DIFF
--- a/.changeset/issue-88-provenance-jsonld.md
+++ b/.changeset/issue-88-provenance-jsonld.md
@@ -1,0 +1,6 @@
+---
+'meta-expression': minor
+---
+
+Add JSON-LD and PROV-O-compatible evidence provenance exports for analyze and
+check results.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T05:28:57.108Z for PR creation at branch issue-88-7fdca54b4623 for issue https://github.com/link-assistant/meta-expression/issues/88

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-26T05:28:57.108Z for PR creation at branch issue-88-7fdca54b4623 for issue https://github.com/link-assistant/meta-expression/issues/88

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Core exports:
   Markdown, and Links Notation.
 - `importClaimReviewJsonLd(input)` and `exportClaimReviewJsonLd(result)` import
   and export Schema.org ClaimReview JSON-LD for fact-check interchange.
+- `exportEvidenceJsonLd(result)` and `exportEvidenceProvJsonLd(result)` export
+  `/analyze` and `/check` evidence provenance as JSON-LD and a PROV-O-compatible
+  JSON-LD graph while preserving Links Notation output.
 - `searchTextUniqueness(input, options)` searches detected statements across
   public web and scholarly APIs, returning existing-likelihood scores,
   citation/rewording suggestions, source matches, HTML, Markdown, and Links
@@ -100,11 +103,13 @@ Real-world confidence is intentionally bounded away from absolute `0%` and
 ```bash
 node js/src/cli.js analyze "1 + 1 = 2"
 node js/src/cli.js analyze --input "Earth orbits the Sun" --format links
+node js/src/cli.js analyze --input "Earth orbits the Sun" --format json-ld
 node js/src/cli.js analyze --input "Paris is the capital of France" --live
 node js/src/cli.js formalize --input "Hawaii is a state." --format markdown
 node js/src/cli.js translate --input "Hawaii is a state." --to ru --format markdown
 node js/src/cli.js check --input "Earth orbits the Sun. 1 + 1 = 1." --format html
 node js/src/cli.js check --input "Earth orbits the Sun." --format claim-review
+node js/src/cli.js check --input "Earth orbits the Sun." --format prov-o
 node js/src/cli.js fact-check --input "Paris is the capital of France." --live
 node js/src/cli.js uniqueness --input "Earth orbits the Sun." --format markdown
 ```
@@ -115,23 +120,25 @@ node js/src/cli.js uniqueness --input "Earth orbits the Sun." --format markdown
 npm start
 curl "http://127.0.0.1:3000/analyze?input=1%20%2B%201%20%3D%202"
 curl "http://127.0.0.1:3000/analyze?input=Earth%20orbits%20the%20Sun&format=links"
+curl "http://127.0.0.1:3000/analyze?input=Earth%20orbits%20the%20Sun&format=json-ld"
 curl "http://127.0.0.1:3000/translate?input=Hawaii%20is%20a%20state.&to=ru&format=markdown"
 curl "http://127.0.0.1:3000/check?input=Earth%20orbits%20the%20Sun.%201%20%2B%201%20%3D%201.&format=html"
 curl "http://127.0.0.1:3000/check?input=Earth%20orbits%20the%20Sun.&format=claim-review"
+curl "http://127.0.0.1:3000/check?input=Earth%20orbits%20the%20Sun.&format=prov-o"
 curl "http://127.0.0.1:3000/uniqueness?input=Earth%20orbits%20the%20Sun.&format=markdown"
 ```
 
 Routes:
 
 - `GET /health`
-- `GET /analyze?input=...&format=json|links&select=0`
+- `GET /analyze?input=...&format=json|links|json-ld|prov-o&select=0`
 - `GET /analyze?input=...&live=true`
 - `POST /analyze` with `{ "input": "...", "format": "json" }`
 - `GET /formalize?input=...&format=json|links|markdown|html`
 - `POST /formalize` with `{ "input": "...", "format": "json" }`
 - `GET /translate?input=...&from=en&to=ru&format=json|links|markdown|html`
 - `POST /translate` with `{ "input": "...", "targetLanguage": "ru" }`
-- `GET /check?input=...&format=json|links|markdown|html|claim-review`
+- `GET /check?input=...&format=json|links|markdown|html|claim-review|json-ld|prov-o`
 - `POST /check` with `{ "input": "...", "live": true }`
 - `GET /fact-check?input=...` and `POST /fact-check` as aliases for
   `/check`

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -6,6 +6,8 @@ import { makeConfig } from 'lino-arguments';
 import {
   analyzeStatement,
   analyzeStatementWithLiveEvidence,
+  exportEvidenceJsonLd,
+  exportEvidenceProvJsonLd,
   naturalizeExpressionWith,
   parsePreferenceProfile,
   serializeLinksNotation,
@@ -778,6 +780,14 @@ function cliAnalysisOptions(options) {
 }
 
 function emitCliAnalysis(options, output, analysis) {
+  if (isProvOFormat(options.format)) {
+    output.log(JSON.stringify(exportEvidenceProvJsonLd(analysis), null, 2));
+    return 0;
+  }
+  if (isJsonLdFormat(options.format)) {
+    output.log(JSON.stringify(exportEvidenceJsonLd(analysis), null, 2));
+    return 0;
+  }
   if (options.format === 'links' || options.format === 'lino') {
     output.log(serializeLinksNotation(analysis.linksNetwork));
     return 0;
@@ -798,6 +808,14 @@ function emitCheckResult(options, output, result) {
         2
       )
     );
+    return 0;
+  }
+  if (isProvOFormat(options.format)) {
+    output.log(JSON.stringify(exportEvidenceProvJsonLd(result), null, 2));
+    return 0;
+  }
+  if (isJsonLdFormat(options.format)) {
+    output.log(JSON.stringify(exportEvidenceJsonLd(result), null, 2));
     return 0;
   }
   if (options.format === 'links' || options.format === 'lino') {
@@ -841,6 +859,24 @@ function isClaimReviewFormat(format) {
   return format === 'claim-review' || format === 'claimreview';
 }
 
+function isJsonLdFormat(format) {
+  return (
+    format === 'json-ld' ||
+    format === 'jsonld' ||
+    format === 'ld+json' ||
+    format === 'evidence-json-ld'
+  );
+}
+
+function isProvOFormat(format) {
+  return (
+    format === 'prov-o' ||
+    format === 'provo' ||
+    format === 'prov' ||
+    format === 'prov-json-ld'
+  );
+}
+
 function isUniquenessCommand(command) {
   return command === 'uniqueness' || command === 'uniquness';
 }
@@ -882,7 +918,7 @@ Commands:
 
 Options:
   -i, --input <text>             Statement text
-  -f, --format <json|links|markdown|html|claim-review>
+  -f, --format <json|links|markdown|html|claim-review|json-ld|prov-o>
   -s, --select <index>           Interpretation index (analyze), default 0
   --live                         analyze: resolve through Wikimedia APIs
   --target <wikipedia|wikidata|local>

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1638,6 +1638,37 @@ export interface ClaimReviewOptions {
   statementIndex?: number;
 }
 
+export interface EvidenceProvenanceExportOptions {
+  baseId?: string;
+  exportedAt?: string | number | Date;
+  now?: () => string | number | Date;
+  linksNotation?: string;
+}
+
+export interface EvidenceJsonLdExport extends Record<string, unknown> {
+  '@context': Record<string, unknown>;
+  '@id': string;
+  '@type': string[];
+  format: 'meta-expression-evidence-json-ld';
+  sourceSurface: 'analyze' | 'check';
+  exportedAt: string;
+  analyses: Record<string, unknown>[];
+  evidenceRecords: Record<string, unknown>[];
+  sources: Record<string, unknown>[];
+  linksNotation: string;
+}
+
+export interface EvidenceProvJsonLdExport extends Record<string, unknown> {
+  '@context': Record<string, string>;
+  '@id': string;
+  '@type': string[];
+  format: 'meta-expression-prov-o-json-ld';
+  sourceSurface: 'analyze' | 'check';
+  exportedAt: string;
+  linksNotation: string;
+  '@graph': Record<string, unknown>[];
+}
+
 export type UniquenessSuggestedAction =
   | 'cite-or-quote'
   | 'review-matches'
@@ -1780,6 +1811,16 @@ export declare function exportClaimReviewJsonLd(
   input: CheckResult | CheckStatement | StatementAnalysis,
   options?: ClaimReviewOptions
 ): Record<string, unknown>;
+
+export declare function exportEvidenceJsonLd(
+  input: StatementAnalysis | CheckResult,
+  options?: EvidenceProvenanceExportOptions
+): EvidenceJsonLdExport;
+
+export declare function exportEvidenceProvJsonLd(
+  input: StatementAnalysis | CheckResult,
+  options?: EvidenceProvenanceExportOptions
+): EvidenceProvJsonLdExport;
 
 export declare function searchTextUniqueness(
   input: string,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -106,6 +106,10 @@ export {
   parseClaimReviewJsonLd,
 } from './claim-review.js';
 export {
+  exportEvidenceJsonLd,
+  exportEvidenceProvJsonLd,
+} from './provenance-jsonld.js';
+export {
   createCrossrefUniquenessSource,
   createDefaultUniquenessSources,
   createDuckDuckGoUniquenessSource,

--- a/js/src/provenance-jsonld.js
+++ b/js/src/provenance-jsonld.js
@@ -1,0 +1,461 @@
+import { serializeLinksNotation } from './reporting.js';
+
+const metaNamespace = 'https://link-assistant.github.io/meta-expression/vocab#';
+const provNamespace = 'http://www.w3.org/ns/prov#';
+const schemaNamespace = 'https://schema.org/';
+const xsdNamespace = 'http://www.w3.org/2001/XMLSchema#';
+
+const jsonLdContext = Object.freeze({
+  meta: metaNamespace,
+  prov: provNamespace,
+  schema: schemaNamespace,
+  xsd: xsdNamespace,
+  analyses: {
+    '@id': 'meta:analysis',
+    '@container': '@set',
+  },
+  evidenceRecords: {
+    '@id': 'meta:evidenceRecord',
+    '@container': '@set',
+  },
+  sources: {
+    '@id': 'meta:source',
+    '@container': '@set',
+  },
+  source: {
+    '@id': 'prov:wasDerivedFrom',
+    '@type': '@id',
+  },
+  confidence: 'meta:confidence',
+  confidenceInputs: {
+    '@id': 'meta:confidenceInput',
+    '@container': '@list',
+  },
+  correctness: 'meta:correctness',
+  linksNotation: 'meta:linksNotation',
+  retrievedAt: 'prov:generatedAtTime',
+});
+
+const provContext = Object.freeze({
+  meta: metaNamespace,
+  prov: provNamespace,
+  schema: schemaNamespace,
+  xsd: xsdNamespace,
+});
+
+export function exportEvidenceJsonLd(input, options = {}) {
+  const model = createProvenanceModel(input, options);
+  return {
+    '@context': jsonLdContext,
+    '@id': model.exportId,
+    '@type': ['meta:EvidenceExport', 'prov:Bundle'],
+    format: 'meta-expression-evidence-json-ld',
+    sourceSurface: model.sourceSurface,
+    exportedAt: model.exportedAt,
+    analyses: model.analyses.map(jsonLdAnalysis),
+    evidenceRecords: model.evidenceRecords.map(jsonLdEvidenceRecord),
+    sources: model.sources.map(jsonLdSource),
+    linksNotation: model.linksNotation,
+  };
+}
+
+export function exportEvidenceProvJsonLd(input, options = {}) {
+  const model = createProvenanceModel(input, options);
+  const graph = [
+    {
+      '@id': model.agentId,
+      '@type': ['prov:Agent', 'prov:SoftwareAgent', 'meta:MetaExpression'],
+      'prov:label': 'meta-expression',
+    },
+    ...model.sources.map(provSource),
+  ];
+
+  for (const analysis of model.analyses) {
+    graph.push(provStatement(analysis), provActivity(analysis, model));
+    graph.push(...analysis.evidenceRecords.map(provEvidenceRecord));
+    graph.push(provResult(analysis));
+  }
+
+  return {
+    '@context': provContext,
+    '@id': model.exportId,
+    '@type': ['prov:Bundle', 'meta:EvidenceProvenanceExport'],
+    format: 'meta-expression-prov-o-json-ld',
+    sourceSurface: model.sourceSurface,
+    exportedAt: model.exportedAt,
+    linksNotation: model.linksNotation,
+    '@graph': graph,
+  };
+}
+
+function createProvenanceModel(input, options) {
+  const sourceSurface = input?.status === 'checked' ? 'check' : 'analyze';
+  if (sourceSurface === 'check' && !Array.isArray(input.statements)) {
+    throw new Error(
+      'Evidence provenance export requires analysis or check output.'
+    );
+  }
+  if (sourceSurface === 'analyze' && input?.status !== 'completed') {
+    throw new Error(
+      'Evidence provenance export requires analysis or check output.'
+    );
+  }
+
+  const baseId = normalizeBaseId(
+    options.baseId ??
+      `urn:meta-expression:${sourceSurface}:${surfaceKey(input)}`
+  );
+  const model = {
+    baseId,
+    exportId: nodeId(baseId, 'evidence-export'),
+    agentId: nodeId(baseId, 'agent-meta-expression'),
+    sourceSurface,
+    exportedAt: timestampFrom(
+      options.exportedAt ?? options.now?.() ?? new Date()
+    ),
+    linksNotation: linksNotationFor(input, options, sourceSurface),
+    analyses: [],
+    evidenceRecords: [],
+    sourceMap: new Map(),
+    sources: [],
+  };
+
+  if (sourceSurface === 'check') {
+    for (const [index, statement] of input.statements.entries()) {
+      model.analyses.push(
+        createAnalysisEntry(statement.analysis, model, {
+          index,
+          statementId: statement.id,
+          statementText: statement.text,
+          statementStart: statement.start,
+          statementEnd: statement.end,
+        })
+      );
+    }
+    return model;
+  }
+
+  model.analyses.push(createAnalysisEntry(input, model, { index: 0 }));
+  return model;
+}
+
+function createAnalysisEntry(analysis, model, source) {
+  const ordinal = source.index + 1;
+  const localId = `analysis-${ordinal}`;
+  const statementText =
+    stringValue(source.statementText) ||
+    stringValue(analysis?.statement?.value?.text);
+  const entry = {
+    analysis,
+    localId,
+    analysisId: nodeId(model.baseId, localId),
+    activityId: nodeId(model.baseId, `activity-${localId}`),
+    statementId: nodeId(
+      model.baseId,
+      source.statementId ?? `statement-${ordinal}`
+    ),
+    statementText,
+    statementStart: source.statementStart ?? null,
+    statementEnd: source.statementEnd ?? null,
+    resultId: nodeId(model.baseId, `result-${ordinal}`),
+    evidenceRecords: [],
+  };
+  const evidenceItems = [
+    ...(analysis?.result?.supportingEvidence ?? []),
+    ...(analysis?.result?.refutingEvidence ?? []),
+  ];
+  entry.evidenceRecords = evidenceItems.map((evidence, index) =>
+    createEvidenceRecord(evidence, entry, index, model)
+  );
+  model.evidenceRecords.push(...entry.evidenceRecords);
+  return entry;
+}
+
+function createEvidenceRecord(evidence, analysis, index, model) {
+  const source = sourceForEvidence(evidence, model);
+  return {
+    id: nodeId(
+      model.baseId,
+      `${analysis.localId}-evidence-${safeReference(evidence.id ?? index + 1)}`
+    ),
+    analysisId: analysis.analysisId,
+    resultId: analysis.resultId,
+    sourceId: source.id,
+    sourceType: source.sourceType,
+    sourceUrl: source.url,
+    retrievedAt: stringValue(evidence.retrievedAt) || null,
+    claim: stringValue(evidence.claim),
+    polarity: stringValue(evidence.polarity) || 'support',
+    weight: finiteNumber(evidence.weight) ?? 0,
+    situation: situationId(evidence.situation),
+    identifiers: jsonCompatible(evidence.identifiers ?? {}),
+  };
+}
+
+function sourceForEvidence(evidence, model) {
+  const sourceType = stringValue(evidence.sourceType) || 'unknown';
+  const url = stringValue(evidence.sourceUrl) || null;
+  const key = `${sourceType}\n${url ?? 'local'}`;
+  const existing = model.sourceMap.get(key);
+  if (existing) {
+    if (!existing.retrievedAt && evidence.retrievedAt) {
+      existing.retrievedAt = stringValue(evidence.retrievedAt);
+    }
+    return existing;
+  }
+
+  const source = {
+    id: nodeId(
+      model.baseId,
+      `source-${safeReference(sourceType)}-${shortHash(key)}`
+    ),
+    sourceType,
+    url,
+    retrievedAt: stringValue(evidence.retrievedAt) || null,
+  };
+  model.sourceMap.set(key, source);
+  model.sources.push(source);
+  return source;
+}
+
+function jsonLdAnalysis(entry) {
+  const result = entry.analysis.result;
+  return {
+    '@id': entry.analysisId,
+    '@type': ['meta:GeneratedAnalysis'],
+    statement: {
+      '@id': entry.statementId,
+      '@type': ['schema:Claim', 'meta:Statement'],
+      text: entry.statementText,
+      start: entry.statementStart,
+      end: entry.statementEnd,
+    },
+    interpretation: {
+      id: entry.analysis.selectedInterpretation?.id ?? null,
+      kind: entry.analysis.selectedInterpretation?.kind ?? null,
+      paraphrase: entry.analysis.selectedInterpretation?.paraphrase ?? null,
+    },
+    result: {
+      '@id': entry.resultId,
+      '@type': ['meta:Result', 'prov:Entity'],
+      kind: result.kind,
+      value: jsonCompatible(result.value),
+      confidence: nullableNumber(result.confidence),
+      probability: nullableNumber(result.probability),
+      correctness: nullableNumber(result.correctness),
+      signedConfidence: nullableNumber(result.signedConfidence),
+      supportWeight: nullableNumber(
+        result.supportWeight ?? result.calculation?.supportWeight
+      ),
+      refuteWeight: nullableNumber(
+        result.refuteWeight ?? result.calculation?.refuteWeight
+      ),
+      confidenceInputs: jsonCompatible(result.calculation?.inputs ?? []),
+      evidenceRecords: entry.evidenceRecords.map((record) => record.id),
+    },
+  };
+}
+
+function jsonLdEvidenceRecord(record) {
+  return {
+    '@id': record.id,
+    '@type': ['meta:EvidenceRecord', 'prov:Entity'],
+    claim: record.claim,
+    polarity: record.polarity,
+    weight: record.weight,
+    situation: record.situation,
+    source: record.sourceId,
+    sourceType: record.sourceType,
+    sourceUrl: record.sourceUrl,
+    retrievedAt: record.retrievedAt,
+    identifiers: record.identifiers,
+    result: record.resultId,
+  };
+}
+
+function jsonLdSource(source) {
+  return {
+    '@id': source.id,
+    '@type': ['meta:EvidenceSource', 'prov:Entity'],
+    sourceType: source.sourceType,
+    url: source.url,
+    retrievedAt: source.retrievedAt,
+  };
+}
+
+function provSource(source) {
+  return {
+    '@id': source.id,
+    '@type': ['prov:Entity', 'meta:EvidenceSource'],
+    'prov:type': source.sourceType,
+    'prov:location': source.url,
+    'prov:generatedAtTime': source.retrievedAt,
+    'meta:sourceType': source.sourceType,
+    'meta:url': source.url,
+  };
+}
+
+function provStatement(analysis) {
+  return {
+    '@id': analysis.statementId,
+    '@type': ['prov:Entity', 'schema:Claim', 'meta:Statement'],
+    'schema:text': analysis.statementText,
+  };
+}
+
+function provActivity(analysis, model) {
+  return {
+    '@id': analysis.activityId,
+    '@type': ['prov:Activity', 'meta:GeneratedAnalysis'],
+    'prov:wasAssociatedWith': model.agentId,
+    'prov:startedAtTime': model.exportedAt,
+    'prov:used': unique(
+      analysis.evidenceRecords.map((record) => record.sourceId)
+    ),
+    'schema:text': analysis.statementText,
+    'meta:selectedInterpretation':
+      analysis.analysis.selectedInterpretation?.kind ?? null,
+  };
+}
+
+function provEvidenceRecord(record) {
+  return {
+    '@id': record.id,
+    '@type': ['prov:Entity', 'meta:EvidenceRecord'],
+    'prov:wasDerivedFrom': record.sourceId,
+    'prov:generatedAtTime': record.retrievedAt,
+    'prov:value': record.claim,
+    'meta:polarity': record.polarity,
+    'meta:weight': record.weight,
+    'meta:situation': record.situation,
+    'meta:sourceType': record.sourceType,
+    'meta:sourceUrl': record.sourceUrl,
+    'meta:result': record.resultId,
+  };
+}
+
+function provResult(analysis) {
+  const result = analysis.analysis.result;
+  return {
+    '@id': analysis.resultId,
+    '@type': ['prov:Entity', 'meta:Result'],
+    'prov:wasGeneratedBy': analysis.activityId,
+    'prov:value': jsonCompatible(result.value),
+    'meta:confidence': nullableNumber(result.confidence),
+    'meta:probability': nullableNumber(result.probability),
+    'meta:correctness': nullableNumber(result.correctness),
+    'meta:signedConfidence': nullableNumber(result.signedConfidence),
+    'meta:confidenceInput': jsonCompatible(result.calculation?.inputs ?? []),
+  };
+}
+
+function linksNotationFor(input, options, sourceSurface) {
+  if (options.linksNotation !== undefined) {
+    return String(options.linksNotation);
+  }
+  if (sourceSurface === 'check') {
+    return input.linksNotation ?? '';
+  }
+  return serializeLinksNotation(input.linksNetwork);
+}
+
+function surfaceKey(input) {
+  const text =
+    input?.text ??
+    input?.statement?.value?.text ??
+    input?.statements?.[0]?.text ??
+    'case';
+  return safeReference(text);
+}
+
+function normalizeBaseId(value) {
+  return String(value ?? 'urn:meta-expression:evidence')
+    .trim()
+    .replace(/[?#]+$/u, '');
+}
+
+function nodeId(baseId, fragment) {
+  return `${baseId}#${safeReference(fragment)}`;
+}
+
+function situationId(value) {
+  if (typeof value === 'object' && value !== null) {
+    return stringValue(value.id) || null;
+  }
+  return stringValue(value) || null;
+}
+
+function timestampFrom(value) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'number') {
+    return new Date(value).toISOString();
+  }
+  return stringValue(value) || new Date().toISOString();
+}
+
+function jsonCompatible(value) {
+  if (value === undefined) {
+    return null;
+  }
+  if (
+    value === null ||
+    ['string', 'number', 'boolean'].includes(typeof value)
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(jsonCompatible);
+  }
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entryValue]) => entryValue !== undefined)
+        .map(([key, entryValue]) => [key, jsonCompatible(entryValue)])
+    );
+  }
+  return String(value);
+}
+
+function nullableNumber(value) {
+  return finiteNumber(value);
+}
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function stringValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value).trim();
+  }
+  return '';
+}
+
+function safeReference(value) {
+  return (
+    String(value)
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'value'
+  );
+}
+
+function shortHash(value) {
+  let hash = 2166136261;
+  for (const char of String(value)) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}

--- a/js/src/server.js
+++ b/js/src/server.js
@@ -3,6 +3,8 @@ import { URL, fileURLToPath } from 'node:url';
 import {
   analyzeStatement,
   analyzeStatementWithLiveEvidence,
+  exportEvidenceJsonLd,
+  exportEvidenceProvJsonLd,
   naturalizeExpressionWith,
   serializeLinksNotation,
 } from './index.js';
@@ -316,6 +318,14 @@ async function sendAnalysis(
     ? await analyzeStatementWithLiveEvidence(input, options)
     : analyzeStatement(input, options);
 
+  if (isProvOFormat(format)) {
+    sendLinkedDataJson(response, 200, exportEvidenceProvJsonLd(analysis));
+    return;
+  }
+  if (isJsonLdFormat(format)) {
+    sendLinkedDataJson(response, 200, exportEvidenceJsonLd(analysis));
+    return;
+  }
   if (format === 'links' || format === 'lino') {
     response.writeHead(200, {
       'content-type': 'text/plain; charset=utf-8',
@@ -572,6 +582,14 @@ function emitCheckResponse(response, format, payload, options = {}) {
     );
     return 0;
   }
+  if (isProvOFormat(format)) {
+    sendLinkedDataJson(response, 200, exportEvidenceProvJsonLd(payload));
+    return 0;
+  }
+  if (isJsonLdFormat(format)) {
+    sendLinkedDataJson(response, 200, exportEvidenceJsonLd(payload));
+    return 0;
+  }
   if (format === 'links' || format === 'lino') {
     response.writeHead(200, {
       'content-type': 'text/plain; charset=utf-8',
@@ -599,6 +617,24 @@ function emitCheckResponse(response, format, payload, options = {}) {
 
 function isClaimReviewFormat(format) {
   return format === 'claim-review' || format === 'claimreview';
+}
+
+function isJsonLdFormat(format) {
+  return (
+    format === 'json-ld' ||
+    format === 'jsonld' ||
+    format === 'ld+json' ||
+    format === 'evidence-json-ld'
+  );
+}
+
+function isProvOFormat(format) {
+  return (
+    format === 'prov-o' ||
+    format === 'provo' ||
+    format === 'prov' ||
+    format === 'prov-json-ld'
+  );
 }
 
 function emitUniquenessResponse(response, format, payload) {
@@ -630,6 +666,13 @@ function emitUniquenessResponse(response, format, payload) {
 function sendJson(response, status, payload) {
   response.writeHead(status, {
     'content-type': 'application/json; charset=utf-8',
+  });
+  response.end(JSON.stringify(payload, null, 2));
+}
+
+function sendLinkedDataJson(response, status, payload) {
+  response.writeHead(status, {
+    'content-type': 'application/ld+json; charset=utf-8',
   });
   response.end(JSON.stringify(payload, null, 2));
 }

--- a/js/tests/integration/issue-88-provenance-jsonld.test.js
+++ b/js/tests/integration/issue-88-provenance-jsonld.test.js
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'test-anywhere';
+import {
+  analyzeStatement,
+  checkText,
+  exportEvidenceJsonLd,
+  exportEvidenceProvJsonLd,
+  serializeLinksNotation,
+} from '../../src/index.js';
+import { runCliAsync } from '../../src/cli.js';
+import { createMetaExpressionServer } from '../../src/server.js';
+
+const exportedAt = '2026-05-26T12:00:00.000Z';
+
+describe('issue 88 - JSON-LD and PROV-O evidence provenance', () => {
+  it('exports /analyze evidence as JSON-LD with result, source, retrieval time, confidence inputs, and Links Notation', () => {
+    const analysis = analyzeStatement('Earth orbits the Sun');
+    const linksNotation = serializeLinksNotation(analysis.linksNetwork);
+    const jsonLd = exportEvidenceJsonLd(analysis, {
+      baseId: 'https://example.org/meta-expression/cases/earth-orbits-sun',
+      exportedAt,
+    });
+
+    expect(jsonLd['@context'].prov).toBe('http://www.w3.org/ns/prov#');
+    expect(jsonLd.format).toBe('meta-expression-evidence-json-ld');
+    expect(jsonLd.sourceSurface).toBe('analyze');
+    expect(jsonLd.linksNotation).toBe(linksNotation);
+    expect(jsonLd.analyses.length).toBe(1);
+    expect(jsonLd.analyses[0].result.confidence).toBe(
+      analysis.result.confidence
+    );
+    expect(
+      jsonLd.analyses[0].result.confidenceInputs.some(
+        (input) => input.kind === 'evidence'
+      )
+    ).toBe(true);
+    expect(jsonLd.evidenceRecords[0].claim).toContain('Wikidata Q2 Earth');
+    expect(jsonLd.evidenceRecords[0].retrievedAt).toBe('2026-04-26');
+    expect(jsonLd.evidenceRecords[0].source).toBe(jsonLd.sources[0]['@id']);
+    expect(jsonLd.sources[0].sourceType).toBe('wikidata');
+    expect(jsonLd.sources[0].url).toBe('https://www.wikidata.org/wiki/Q2#P397');
+  });
+
+  it('projects /analyze evidence into a PROV-O-compatible JSON-LD graph', () => {
+    const analysis = analyzeStatement('Earth orbits the Sun');
+    const prov = exportEvidenceProvJsonLd(analysis, {
+      baseId: 'https://example.org/meta-expression/cases/earth-orbits-sun',
+      exportedAt,
+    });
+    const activity = graphNode(prov, 'prov:Activity');
+    const agent = graphNode(prov, 'prov:SoftwareAgent');
+    const evidence = graphNode(prov, 'meta:EvidenceRecord');
+    const source = graphNode(prov, 'meta:EvidenceSource');
+    const result = graphNode(prov, 'meta:Result');
+
+    expect(prov['@context'].prov).toBe('http://www.w3.org/ns/prov#');
+    expect(activity['prov:wasAssociatedWith']).toBe(agent['@id']);
+    expect(activity['prov:used']).toContain(source['@id']);
+    expect(evidence['prov:wasDerivedFrom']).toBe(source['@id']);
+    expect(evidence['prov:generatedAtTime']).toBe('2026-04-26');
+    expect(result['prov:wasGeneratedBy']).toBe(activity['@id']);
+  });
+
+  it('exports /check evidence as JSON-LD without dropping the existing Links Notation output', () => {
+    const checked = checkText('Earth orbits the Sun. 1 + 1 = 1.');
+    const jsonLd = exportEvidenceJsonLd(checked, {
+      baseId: 'https://example.org/meta-expression/cases/check-output',
+      exportedAt,
+    });
+
+    expect(jsonLd.sourceSurface).toBe('check');
+    expect(jsonLd.linksNotation).toBe(checked.linksNotation);
+    expect(jsonLd.analyses.map((analysis) => analysis.statement.text)).toEqual([
+      'Earth orbits the Sun.',
+      '1 + 1 = 1.',
+    ]);
+    expect(
+      jsonLd.evidenceRecords.some((record) => record.polarity === 'support')
+    ).toBe(true);
+    expect(
+      jsonLd.evidenceRecords.some((record) => record.polarity === 'refute')
+    ).toBe(true);
+  });
+
+  it('supports JSON-LD and PROV-O as analyze/check export formats in CLI and HTTP surfaces', async () => {
+    const output = {
+      logs: [],
+      errors: [],
+      log(value) {
+        this.logs.push(value);
+      },
+      error(value) {
+        this.errors.push(value);
+      },
+    };
+    const exitCode = await runCliAsync(
+      ['analyze', '--input', 'Earth orbits the Sun', '--format', 'json-ld'],
+      output
+    );
+    const cliPayload = JSON.parse(output.logs[0]);
+    const started = await startServer();
+
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${started.port}/check?input=${encodeURIComponent(
+          'Earth orbits the Sun.'
+        )}&format=prov-o`
+      );
+      const servicePayload = await response.json();
+
+      expect(exitCode).toBe(0);
+      expect(cliPayload.format).toBe('meta-expression-evidence-json-ld');
+      expect(cliPayload.sourceSurface).toBe('analyze');
+      expect(response.status).toBe(200);
+      expect(
+        graphNode(servicePayload, 'prov:Activity')['prov:used'].length
+      ).toBe(1);
+    } finally {
+      await stopServer(started.server);
+    }
+  });
+});
+
+function graphNode(document, type) {
+  return document['@graph'].find((node) => nodeTypes(node).includes(type));
+}
+
+function nodeTypes(node) {
+  return Array.isArray(node['@type']) ? node['@type'] : [node['@type']];
+}
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const server = createMetaExpressionServer({
+      cacheRoot: '.cache/issue-88-test',
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}


### PR DESCRIPTION
## What

Adds standards-oriented provenance exports for existing evidence results:

- `exportEvidenceJsonLd(result)` for `/analyze` and `/check` outputs, including evidence records, result metrics, source URLs, retrieval timestamps, confidence inputs, and preserved Links Notation.
- `exportEvidenceProvJsonLd(result)` as a PROV-O-compatible JSON-LD graph mapping sources and evidence records to `prov:Entity`, generated analyses to `prov:Activity`, and meta-expression to a software agent.
- CLI and HTTP `format=json-ld` / `format=prov-o` handling for `analyze` and `check`.

Fixes #88

## Reproduction

Before this PR, importing `exportEvidenceJsonLd` from `js/src/index.js` failed because the evidence provenance JSON-LD export did not exist.

## Testing

- `node --test js/tests/integration/issue-88-provenance-jsonld.test.js`
- `npm run test:integration`
- `npm test`
- `npm run check`
- `bash scripts/check-file-line-limits.sh`