### PR TITLE
Add candidate formalization providers

### DIFF
--- a/.changeset/issue-89-formalization-providers.md
+++ b/.changeset/issue-89-formalization-providers.md
@@ -1,0 +1,6 @@
+---
+'meta-expression': minor
+---
+
+Add candidate-only formalization provider output for OpenIE, AMR, SRL, entity
+links, and semantic graphs.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89

--- a/docs/FORMALIZE.md
+++ b/docs/FORMALIZE.md
@@ -53,24 +53,26 @@ one or more knowledge graphs, picking the longest non-overlapping
 cover, and producing renderings (Markdown, HTML, Links Notation) plus
 aggregated big contexts and ranked interpretations.
 
-| Parameter                      | Type                        | Description           |
-| ------------------------------ | --------------------------- | --------------------- |
-| `input`                        | `string`                    | —                     |
-| `[options]`                    | `object`                    | —                     |
-| `[options.fetch]`              | `Function\|null`            | fetch implementation  |
-| `[options.cache]`              | `Map<string,unknown>\|null` | TTL cache             |
-| `[options.cacheTtlMs]`         | `number`                    | —                     |
-| `[options.now]`                | `Function`                  | —                     |
-| `[options.maxNgramSize]`       | `number`                    | —                     |
-| `[options.searchLimit]`        | `number`                    | —                     |
-| `[options.topKCandidates]`     | `number`                    | —                     |
-| `[options.maxInterpretations]` | `number`                    | —                     |
-| `[options.linkTargetMode]`     | `string`                    | —                     |
-| `[options.contextLens]`        | `string\|object\|null`      | —                     |
-| `[options.language]`           | `string`                    | —                     |
-| `[options.sources]`            | `object[]`                  | pluggable source list |
-| `[options.overrides]`          | `object[]`                  | repo+user overrides   |
-| `[options.contextOptions]`     | `object`                    | passed to aggregator  |
+| Parameter                      | Type                        | Description                 |
+| ------------------------------ | --------------------------- | --------------------------- |
+| `input`                        | `string`                    | —                           |
+| `[options]`                    | `object`                    | —                           |
+| `[options.fetch]`              | `Function\|null`            | fetch implementation        |
+| `[options.cache]`              | `Map<string,unknown>\|null` | TTL cache                   |
+| `[options.cacheTtlMs]`         | `number`                    | —                           |
+| `[options.now]`                | `Function`                  | —                           |
+| `[options.maxNgramSize]`       | `number`                    | —                           |
+| `[options.searchLimit]`        | `number`                    | —                           |
+| `[options.topKCandidates]`     | `number`                    | —                           |
+| `[options.maxInterpretations]` | `number`                    | —                           |
+| `[options.linkTargetMode]`     | `string`                    | —                           |
+| `[options.contextLens]`        | `string\|object\|null`      | —                           |
+| `[options.language]`           | `string`                    | —                           |
+| `[options.sources]`            | `object[]`                  | pluggable source list       |
+| `[options.overrides]`          | `object[]`                  | repo+user overrides         |
+| `[options.providers]`          | `object[]`                  | OpenIE/AMR/SRL/etc.         |
+| `[options.providerOutputs]`    | `object[]\|object`          | precomputed provider output |
+| `[options.contextOptions]`     | `object`                    | passed to aggregator        |
 
 **Returns** `Promise<object>`
 

--- a/docs/case-studies/issue-89/README.md
+++ b/docs/case-studies/issue-89/README.md
@@ -1,0 +1,53 @@
+# Issue 89: Candidate Formalization Providers
+
+Issue: <https://github.com/link-assistant/meta-expression/issues/89>
+PR: <https://github.com/link-assistant/meta-expression/pull/101>
+
+## Summary
+
+Issue 89 adds a candidate-only provider interface for OpenIE, AMR, SRL, entity
+linking, and similar formalization adapters. Provider output can now be passed
+to `formalizeTextWith()` through `providers` or to the HTTP `/formalize` route
+through `providerOutputs`.
+
+The deterministic formalizer still owns token coverage, entity selection,
+contexts, interpretations, Markdown, and HTML. Provider records are attached as
+`providerCandidates`, mirrored into the formalization CST, and emitted into the
+Links Network for downstream selection or validation.
+
+## Provider Contract
+
+Provider adapters expose `extract(text, ctx)` and return candidate bundles with
+any mix of:
+
+- triples from OpenIE-style extraction;
+- semantic role frames from SRL;
+- entity-link candidates;
+- graph records such as AMR strings or node/edge graphs.
+
+Static fixtures can use `createFixtureFormalizationProvider(fixture)` to follow
+the same async interface as live adapters.
+
+## Truth Scoring Boundary
+
+Unsupported or unselected provider output remains partial. `/formalize` records
+it with:
+
+- `status: "candidate"` unless the provider explicitly marks it selected or
+  validated;
+- `truthScoring.included: false`;
+- `truthScoring.eligible: false` for plain candidates;
+- no `supportingEvidence` or `refutingEvidence` fields in the formalize result.
+
+Selected or validated provider records can be passed forward as structured
+input for another stage, but `/formalize` still does not score them as truth
+evidence. That keeps NLP/LLM extraction output out of belief calculations until
+a downstream workflow validates it.
+
+## Verification
+
+Focused regression:
+
+```bash
+node --test js/tests/integration/issue-89.test.js
+```

--- a/js/src/formalization-providers.js
+++ b/js/src/formalization-providers.js
@@ -1,0 +1,416 @@
+export const FORMALIZATION_PROVIDER_STATUS = Object.freeze({
+  CANDIDATE: 'candidate',
+  SELECTED: 'selected',
+  VALIDATED: 'validated',
+});
+
+const defaultCandidateReason =
+  'Provider output is a candidate formalization and is not evidence until selected or validated.';
+
+/**
+ * Wrap a static fixture in the same async provider interface used by live
+ * OpenIE, AMR, SRL, LLM, or entity-linking adapters.
+ *
+ * @param {object} fixture
+ * @returns {object}
+ */
+export function createFixtureFormalizationProvider(fixture) {
+  const descriptor = Array.isArray(fixture) ? {} : (fixture ?? {});
+  return {
+    id: descriptor.id ?? 'fixture-formalization-provider',
+    name: descriptor.name ?? descriptor.id ?? 'Fixture formalization provider',
+    kind: descriptor.kind ?? 'fixture',
+    sourceType: descriptor.sourceType ?? 'formalization-provider',
+    version: descriptor.version ?? null,
+    extract() {
+      return Promise.resolve(fixture);
+    },
+  };
+}
+
+/**
+ * Collect candidate structures from static provider output and async provider
+ * adapters. These candidates are intentionally recorded as partial
+ * formalization suggestions; `/formalize` never treats them as truth evidence.
+ *
+ * @param {string} text
+ * @param {object} [options]
+ * @param {object[]} [options.providers]
+ * @param {object[]|object} [options.providerOutputs]
+ * @param {string} [options.language]
+ * @param {Function} [options.now]
+ * @param {object[]} [options.steps]
+ * @returns {Promise<object>}
+ */
+export async function collectFormalizationProviderCandidates(
+  text,
+  options = {}
+) {
+  const rawOutputs = normalizeArray(options.providerOutputs);
+  const providerResults = await Promise.all(
+    normalizeArray(options.providers).map((provider, index) =>
+      invokeProvider(provider, index, text, options)
+    )
+  );
+  const bundles = [
+    ...rawOutputs.flatMap((output, index) =>
+      expandProviderOutput(output, {
+        id: `provider-output-${index + 1}`,
+      })
+    ),
+    ...providerResults.flatMap((result) =>
+      expandProviderOutput(result.output, result.descriptor)
+    ),
+  ].map((bundle, index) => normalizeProviderBundle(bundle, index));
+
+  const providerCandidates = buildProviderCandidateSet(bundles);
+  if (options.trace !== false && providerCandidates.providers.length > 0) {
+    options.steps?.push({
+      type: 'formalization-provider-candidates',
+      providers: providerCandidates.providers.map((provider) => provider.id),
+      triples: providerCandidates.triples.length,
+      roles: providerCandidates.roles.length,
+      entityLinks: providerCandidates.entityLinks.length,
+      graphs: providerCandidates.graphs.length,
+    });
+  }
+  return providerCandidates;
+}
+
+async function invokeProvider(provider, index, text, options) {
+  const descriptor = providerDescriptor(provider, index);
+  if (!provider || typeof provider.extract !== 'function') {
+    return {
+      descriptor,
+      output: {
+        ...descriptor,
+        diagnostics: [
+          {
+            level: 'error',
+            message: 'Formalization provider must expose extract(text, ctx).',
+          },
+        ],
+      },
+    };
+  }
+  try {
+    const output = await provider.extract(text, {
+      language: options.language ?? 'en',
+      now: options.now,
+    });
+    return { descriptor, output };
+  } catch (error) {
+    return {
+      descriptor,
+      output: {
+        ...descriptor,
+        diagnostics: [
+          {
+            level: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          },
+        ],
+      },
+    };
+  }
+}
+
+function providerDescriptor(provider, index) {
+  return {
+    id: provider?.id ?? `formalization-provider-${index + 1}`,
+    name:
+      provider?.name ?? provider?.id ?? `Formalization provider ${index + 1}`,
+    kind: provider?.kind ?? 'provider',
+    sourceType: provider?.sourceType ?? 'formalization-provider',
+    version: provider?.version ?? null,
+  };
+}
+
+function expandProviderOutput(output, descriptor) {
+  if (Array.isArray(output)) {
+    return output.flatMap((entry) => expandProviderOutput(entry, descriptor));
+  }
+  if (!output || typeof output !== 'object') {
+    return [{ ...descriptor, diagnostics: [] }];
+  }
+  if (
+    output.type === 'formalization-provider-candidates' &&
+    Array.isArray(output.providers)
+  ) {
+    return output.providers.map((provider) => ({
+      ...descriptor,
+      ...provider,
+      triples: (output.triples ?? []).filter(
+        (entry) => entry.providerId === provider.id
+      ),
+      roles: (output.roles ?? []).filter(
+        (entry) => entry.providerId === provider.id
+      ),
+      entityLinks: (output.entityLinks ?? []).filter(
+        (entry) => entry.providerId === provider.id
+      ),
+      graphs: (output.graphs ?? []).filter(
+        (entry) => entry.providerId === provider.id
+      ),
+      diagnostics: [
+        ...(provider.diagnostics ?? []),
+        ...(output.diagnostics ?? []).filter(
+          (entry) => entry.providerId === provider.id
+        ),
+      ],
+    }));
+  }
+  return [{ ...descriptor, ...output }];
+}
+
+function normalizeProviderBundle(raw, index) {
+  const id = cleanString(raw.id) || `formalization-provider-${index + 1}`;
+  const status = normalizeStatus(raw.status);
+  const sourceType = cleanString(raw.sourceType) || 'formalization-provider';
+  const provenance = {
+    sourceType,
+    method: cleanString(raw.kind) || cleanString(raw.name) || id,
+    providerId: id,
+    providerVersion: cleanString(raw.version) || null,
+    retrievedAt: cleanString(raw.retrievedAt) || null,
+  };
+  const provider = {
+    id,
+    name: cleanString(raw.name) || id,
+    kind: cleanString(raw.kind) || 'provider',
+    sourceType,
+    version: cleanString(raw.version) || null,
+    status,
+    retrievedAt: cleanString(raw.retrievedAt) || null,
+    confidence: finiteNumber(raw.confidence),
+    truthScoring: truthScoringForStatus(status),
+    provenance,
+    diagnostics: normalizeDiagnostics(raw.diagnostics, id),
+  };
+  const context = { provider, provenance, status };
+  const triples = normalizeArray(raw.triples).map((entry, itemIndex) =>
+    normalizeTriple(entry, itemIndex, context)
+  );
+  const roles = normalizeArray(raw.roles).map((entry, itemIndex) =>
+    normalizeRole(entry, itemIndex, context)
+  );
+  const entityLinks = normalizeArray(raw.entityLinks ?? raw.entities).map(
+    (entry, itemIndex) => normalizeEntityLink(entry, itemIndex, context)
+  );
+  const graphs = normalizeArray(raw.graphs).map((entry, itemIndex) =>
+    normalizeGraph(entry, itemIndex, context)
+  );
+  provider.candidateCounts = {
+    triples: triples.length,
+    roles: roles.length,
+    entityLinks: entityLinks.length,
+    graphs: graphs.length,
+  };
+  return { provider, triples, roles, entityLinks, graphs };
+}
+
+function normalizeTriple(raw, index, context) {
+  const status = normalizeStatus(raw.status, context.status);
+  return {
+    id: cleanString(raw.id) || `${context.provider.id}-triple-${index + 1}`,
+    providerId: context.provider.id,
+    kind: 'triple',
+    subject: normalizeProviderPart(raw.subject),
+    predicate: normalizeProviderPart(raw.predicate ?? raw.relation),
+    object: normalizeProviderPart(raw.object),
+    confidence: finiteNumber(raw.confidence),
+    status,
+    selected: raw.selected === true || status === 'selected',
+    validated: raw.validated === true || status === 'validated',
+    truthScoring: truthScoringForStatus(status),
+    provenance: context.provenance,
+  };
+}
+
+function normalizeRole(raw, index, context) {
+  const status = normalizeStatus(raw.status, context.status);
+  return {
+    id: cleanString(raw.id) || `${context.provider.id}-role-${index + 1}`,
+    providerId: context.provider.id,
+    kind: 'semantic-role-frame',
+    predicate: normalizeProviderPart(raw.predicate),
+    arguments: normalizeArray(raw.arguments).map((argument, argumentIndex) => ({
+      id:
+        cleanString(argument.id) ||
+        `${context.provider.id}-role-${index + 1}-argument-${argumentIndex + 1}`,
+      role: cleanString(argument.role) || `ARG${argumentIndex}`,
+      ...normalizeProviderPart(argument),
+    })),
+    confidence: finiteNumber(raw.confidence),
+    status,
+    selected: raw.selected === true || status === 'selected',
+    validated: raw.validated === true || status === 'validated',
+    truthScoring: truthScoringForStatus(status),
+    provenance: context.provenance,
+  };
+}
+
+function normalizeEntityLink(raw, index, context) {
+  const status = normalizeStatus(raw.status, context.status);
+  return {
+    id:
+      cleanString(raw.id) || `${context.provider.id}-entity-link-${index + 1}`,
+    providerId: context.provider.id,
+    kind: 'entity-link',
+    ...normalizeProviderPart(raw),
+    target: normalizeProviderTarget(raw.target ?? raw.entity ?? raw.candidate),
+    confidence: finiteNumber(raw.confidence),
+    status,
+    selected: raw.selected === true || status === 'selected',
+    validated: raw.validated === true || status === 'validated',
+    truthScoring: truthScoringForStatus(status),
+    provenance: context.provenance,
+  };
+}
+
+function normalizeGraph(raw, index, context) {
+  const status = normalizeStatus(raw.status, context.status);
+  return {
+    id: cleanString(raw.id) || `${context.provider.id}-graph-${index + 1}`,
+    providerId: context.provider.id,
+    kind: 'semantic-graph',
+    format: cleanString(raw.format) || 'provider-graph',
+    text: cleanString(raw.text) || '',
+    nodes: normalizeArray(raw.nodes),
+    edges: normalizeArray(raw.edges),
+    confidence: finiteNumber(raw.confidence),
+    status,
+    selected: raw.selected === true || status === 'selected',
+    validated: raw.validated === true || status === 'validated',
+    truthScoring: truthScoringForStatus(status),
+    provenance: context.provenance,
+  };
+}
+
+function normalizeProviderPart(raw) {
+  if (typeof raw === 'string') {
+    return {
+      text: raw,
+      sourceStart: null,
+      sourceEnd: null,
+      target: null,
+    };
+  }
+  const span = normalizeSpan(raw?.span ?? raw);
+  return {
+    text: cleanString(raw?.text ?? raw?.label) || '',
+    sourceStart: span.sourceStart,
+    sourceEnd: span.sourceEnd,
+    target: normalizeProviderTarget(raw?.target ?? raw?.entity ?? null),
+  };
+}
+
+function normalizeProviderTarget(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  return {
+    id: cleanString(raw.id) || null,
+    label: cleanString(raw.label) || null,
+    description: cleanString(raw.description) || null,
+    kind: cleanString(raw.kind) || null,
+    source: cleanString(raw.source) || null,
+    sourceUrl: cleanString(raw.sourceUrl ?? raw.url) || null,
+  };
+}
+
+function normalizeSpan(raw) {
+  if (Array.isArray(raw)) {
+    return {
+      sourceStart: integerOrNull(raw[0]),
+      sourceEnd: integerOrNull(raw[1]),
+    };
+  }
+  return {
+    sourceStart: integerOrNull(raw?.sourceStart ?? raw?.start),
+    sourceEnd: integerOrNull(raw?.sourceEnd ?? raw?.end),
+  };
+}
+
+function buildProviderCandidateSet(bundles) {
+  const providers = bundles.map((bundle) => bundle.provider);
+  const triples = bundles.flatMap((bundle) => bundle.triples);
+  const roles = bundles.flatMap((bundle) => bundle.roles);
+  const entityLinks = bundles.flatMap((bundle) => bundle.entityLinks);
+  const graphs = bundles.flatMap((bundle) => bundle.graphs);
+  const diagnostics = providers.flatMap((provider) => provider.diagnostics);
+  return {
+    type: 'formalization-provider-candidates',
+    version: 1,
+    status: providers.length > 0 ? 'candidate-only' : 'empty',
+    truthScoring: truthScoringForStatus('candidate'),
+    providers,
+    triples,
+    roles,
+    entityLinks,
+    graphs,
+    diagnostics,
+  };
+}
+
+function normalizeDiagnostics(raw, providerId) {
+  return normalizeArray(raw).map((diagnostic, index) => ({
+    id: cleanString(diagnostic.id) || `${providerId}-diagnostic-${index + 1}`,
+    providerId,
+    level: cleanString(diagnostic.level) || 'info',
+    message: cleanString(diagnostic.message) || '',
+  }));
+}
+
+function truthScoringForStatus(status) {
+  if (status === 'candidate') {
+    return {
+      included: false,
+      eligible: false,
+      reason: defaultCandidateReason,
+    };
+  }
+  return {
+    included: false,
+    eligible: true,
+    reason:
+      '/formalize records selected or validated provider output as structured input, but does not score it as truth evidence.',
+  };
+}
+
+function normalizeStatus(value, fallback = 'candidate') {
+  const normalized = cleanString(value || fallback).toLowerCase();
+  if (
+    normalized === FORMALIZATION_PROVIDER_STATUS.SELECTED ||
+    normalized === FORMALIZATION_PROVIDER_STATUS.VALIDATED
+  ) {
+    return normalized;
+  }
+  return FORMALIZATION_PROVIDER_STATUS.CANDIDATE;
+}
+
+function normalizeArray(value) {
+  if (Array.isArray(value)) {
+    return value.filter((entry) => entry !== null && entry !== undefined);
+  }
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return [value];
+}
+
+function cleanString(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function finiteNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function integerOrNull(value) {
+  return Number.isInteger(value) ? value : null;
+}

--- a/js/src/formalize-cache.js
+++ b/js/src/formalize-cache.js
@@ -62,6 +62,7 @@ export function cacheKey(input) {
     noRepoOverrides: Boolean(input.noRepoOverrides),
     maxNgramSize: input.maxNgramSize ?? null,
     language: input.language ?? 'en',
+    providerOutputs: input.providerOutputs ?? null,
   });
   return createHash('sha256').update(normalized).digest('hex').slice(0, 32);
 }

--- a/js/src/formalize-links-network.js
+++ b/js/src/formalize-links-network.js
@@ -5,7 +5,8 @@ export function buildLinksNetwork(
   text,
   phrases,
   contexts,
-  linguisticMetadata = null
+  linguisticMetadata = null,
+  providerCandidates = null
 ) {
   const inputId = 'formalize-input-1';
   const links = [
@@ -39,6 +40,7 @@ export function buildLinksNetwork(
       buildLinguisticRelationLink(relation, index, inputId, fragmentLinkIds)
     );
   });
+  appendProviderCandidateLinks(links, providerCandidates, inputId);
   return {
     id: 'formalize-links-network',
     kind: 'links-network',
@@ -53,6 +55,8 @@ export function buildLinksNetwork(
         fandom: 0.6,
         lexical: 0.5,
         algorithm: 0.5,
+        'formalization-provider': 0.4,
+        'nlp-provider': 0.4,
       },
     },
     links,
@@ -184,6 +188,105 @@ function buildLinguisticRelationLink(
       sourceType: relation.provenance?.sourceType ?? 'algorithm',
       method: relation.provenance?.method ?? 'linguistic-metadata',
     },
+  };
+}
+
+function appendProviderCandidateLinks(links, providerCandidates, inputId) {
+  if (!providerCandidates?.providers?.length) {
+    return;
+  }
+  const providerLinkIds = new Map();
+  providerCandidates.providers.forEach((provider, index) => {
+    const link = buildProviderCandidateBundleLink(provider, index, inputId);
+    providerLinkIds.set(provider.id, link.id);
+    links.push(link);
+  });
+  appendProviderRecords(
+    links,
+    providerCandidates.triples,
+    'provider-candidate-triple',
+    'triple',
+    inputId,
+    providerLinkIds
+  );
+  appendProviderRecords(
+    links,
+    providerCandidates.roles,
+    'provider-candidate-role',
+    'semantic-role-frame',
+    inputId,
+    providerLinkIds
+  );
+  appendProviderRecords(
+    links,
+    providerCandidates.entityLinks,
+    'provider-candidate-entity-link',
+    'entity-link',
+    inputId,
+    providerLinkIds
+  );
+  appendProviderRecords(
+    links,
+    providerCandidates.graphs,
+    'provider-candidate-graph',
+    'semantic-graph',
+    inputId,
+    providerLinkIds
+  );
+}
+
+function buildProviderCandidateBundleLink(provider, index, inputId) {
+  return {
+    id: `formalize-provider-candidate-bundle-${index + 1}`,
+    role: 'provider-candidate-bundle',
+    references: [inputId],
+    value: {
+      providerId: provider.id,
+      name: provider.name,
+      kind: provider.kind,
+      status: provider.status,
+      confidence: provider.confidence,
+      candidateCounts: provider.candidateCounts,
+      truthScoring: provider.truthScoring,
+    },
+    provenance: providerLinkProvenance(provider),
+  };
+}
+
+function appendProviderRecords(
+  links,
+  records,
+  role,
+  kind,
+  inputId,
+  providerLinkIds
+) {
+  (records ?? []).forEach((record, index) => {
+    links.push({
+      id: `formalize-${role}-${index + 1}`,
+      role,
+      references: [
+        inputId,
+        providerLinkIds.get(record.providerId) ?? null,
+      ].filter(Boolean),
+      value: {
+        kind,
+        ...record,
+      },
+      provenance: providerLinkProvenance(record),
+    });
+  });
+}
+
+function providerLinkProvenance(record) {
+  const provenance = record.provenance ?? {};
+  return {
+    sourceType: provenance.sourceType ?? 'formalization-provider',
+    method: provenance.method ?? record.kind ?? 'provider',
+    sourceUrl: provenance.sourceUrl ?? record.sourceUrl ?? null,
+    retrievedAt: provenance.retrievedAt ?? record.retrievedAt ?? null,
+    providerId: provenance.providerId ?? record.providerId ?? record.id ?? null,
+    providerVersion: provenance.providerVersion ?? record.version ?? null,
   };
 }
 

--- a/js/src/formalize-renderers.js
+++ b/js/src/formalize-renderers.js
@@ -57,14 +57,46 @@ export function renderLinksNotation(cst) {
     (relation) =>
       `(${relation.id}: ${relation.type} subject ${relation.subjectFragmentId} predicate ${relation.predicateFragmentId} object ${relation.objectFragmentId ?? 'none'})`
   );
+  const providerCandidateLines = renderProviderCandidateLines(
+    cst.providerCandidates
+  );
   return [
     head,
     ...phraseLines,
     ...fragmentLines,
     ...dependencyLines,
     ...relationLines,
+    ...providerCandidateLines,
     ...contextLines,
   ].join('\n');
+}
+
+function renderProviderCandidateLines(providerCandidates) {
+  if (!providerCandidates?.providers?.length) {
+    return [];
+  }
+  return [
+    ...providerCandidates.providers.map(
+      (provider) =>
+        `(${provider.id}: providerCandidate kind ${toLino(provider.kind)} status ${provider.status} partial ${provider.truthScoring?.included === false})`
+    ),
+    ...providerCandidates.triples.map(
+      (triple) =>
+        `(${triple.id}: providerTriple provider ${triple.providerId} status ${triple.status} subject ${toLino(triple.subject?.text ?? '')} predicate ${toLino(triple.predicate?.text ?? '')} object ${toLino(triple.object?.text ?? '')} evidenceIncluded ${triple.truthScoring?.included === true})`
+    ),
+    ...providerCandidates.roles.map(
+      (role) =>
+        `(${role.id}: providerRole provider ${role.providerId} status ${role.status} predicate ${toLino(role.predicate?.text ?? '')} arguments ${role.arguments.length} evidenceIncluded ${role.truthScoring?.included === true})`
+    ),
+    ...providerCandidates.entityLinks.map(
+      (entityLink) =>
+        `(${entityLink.id}: providerEntityLink provider ${entityLink.providerId} status ${entityLink.status} source ${toLino(entityLink.text ?? '')} target ${toLino(entityLink.target?.id ?? 'none')} evidenceIncluded ${entityLink.truthScoring?.included === true})`
+    ),
+    ...providerCandidates.graphs.map(
+      (graph) =>
+        `(${graph.id}: providerGraph provider ${graph.providerId} status ${graph.status} format ${toLino(graph.format)} evidenceIncluded ${graph.truthScoring?.included === true})`
+    ),
+  ];
 }
 
 function markdownFromCstPhrase(phrase) {

--- a/js/src/formalize.js
+++ b/js/src/formalize.js
@@ -43,6 +43,7 @@ import {
   extractLinguisticMetadata,
 } from './linguistic-metadata.js';
 import { buildLinksNetwork } from './formalize-links-network.js';
+import { collectFormalizationProviderCandidates } from './formalization-providers.js';
 import {
   escapeAttribute,
   escapeHtml,
@@ -233,6 +234,8 @@ export function formalizeText(input, options = {}) {
  * @param {string} [options.language]
  * @param {object[]} [options.sources]               — pluggable source list
  * @param {object[]} [options.overrides]             — repo+user overrides
+ * @param {object[]} [options.providers]             — OpenIE/AMR/SRL/etc.
+ * @param {object[]|object} [options.providerOutputs] — precomputed provider output
  * @param {object} [options.contextOptions]          — passed to aggregator
  * @returns {Promise<object>}
  */
@@ -280,18 +283,24 @@ export async function formalizeTextWith(input, options = {}) {
     flatContexts,
     config
   );
+  const providerCandidates = await collectFormalizationProviderCandidates(
+    text,
+    config
+  );
   const cst = buildFormalizationCst(
     text,
     tokens,
     reranked,
     flatContexts,
-    config
+    config,
+    providerCandidates
   );
   const linksNetwork = buildLinksNetwork(
     text,
     reranked,
     flatContexts,
-    cst.linguisticMetadata
+    cst.linguisticMetadata,
+    providerCandidates
   );
   const markdown = renderMarkdownFromFormalizationCst(cst);
   const html = htmlFromFormalizationCst(cst);
@@ -309,6 +318,7 @@ export async function formalizeTextWith(input, options = {}) {
     bigContexts: bigContexts.all,
     mainBigContext: bigContexts.main,
     additionalBigContexts: bigContexts.additional,
+    providerCandidates,
     interpretations,
     markdown,
     html,
@@ -497,6 +507,8 @@ function createConfig(options) {
     sources,
     cache: options.cache ?? new Map(),
     overrides: buildOverrideMap(options.overrides ?? []),
+    providers: normalizeOptionalArray(options.providers),
+    providerOutputs: options.providerOutputs ?? [],
     trace: options.trace !== false,
     steps: [],
     ...collectFormalizationTransformationRules(options),
@@ -1322,7 +1334,24 @@ function generateFormalizeInterpretations(phrases, contexts, config) {
     .map((interpretation, index) => ({ ...interpretation, rank: index + 1 }));
 }
 
-function buildFormalizationCst(text, tokens, phrases, contexts, config) {
+function normalizeOptionalArray(value) {
+  if (Array.isArray(value)) {
+    return value.filter((entry) => entry !== null && entry !== undefined);
+  }
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return [value];
+}
+
+function buildFormalizationCst(
+  text,
+  tokens,
+  phrases,
+  contexts,
+  config,
+  providerCandidates
+) {
   const tokenSpans = sourceTokenSpans(text, tokens);
   const cstPhrases = phrases.map((phrase, index) =>
     buildCstPhrase(phrase, index, config, tokenSpans)
@@ -1342,6 +1371,7 @@ function buildFormalizationCst(text, tokens, phrases, contexts, config) {
     linkTargetMode: config.linkTargetMode,
     ast: linguisticMetadata.ast,
     linguisticMetadata,
+    providerCandidates,
     phrases: cstPhrases,
     contexts: contexts.all.map((context, index) => ({
       id: `context-${index + 1}`,

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -665,6 +665,17 @@ export declare const FORMALIZE_LINK_TARGETS: {
   readonly LOCAL: 'local-viewer';
 };
 
+export type FormalizationProviderStatus =
+  | 'candidate'
+  | 'selected'
+  | 'validated';
+
+export declare const FORMALIZATION_PROVIDER_STATUS: {
+  readonly CANDIDATE: 'candidate';
+  readonly SELECTED: 'selected';
+  readonly VALIDATED: 'validated';
+};
+
 export type InterpretationDisplayMode =
   | 'id'
   | 'name'
@@ -903,6 +914,143 @@ export interface FormalizeContext {
   phrases: Array<{ text: string; entityId: string }>;
 }
 
+export interface FormalizationProviderTruthScoring {
+  included: false;
+  eligible: boolean;
+  reason: string;
+}
+
+export interface FormalizationProviderProvenance {
+  sourceType: string;
+  method: string;
+  providerId: string;
+  providerVersion: string | null;
+  retrievedAt: string | null;
+  sourceUrl?: string | null;
+}
+
+export interface FormalizationProviderTarget {
+  id: string | null;
+  label: string | null;
+  description: string | null;
+  kind: string | null;
+  source: string | null;
+  sourceUrl: string | null;
+}
+
+export interface FormalizationProviderPart {
+  text: string;
+  sourceStart: number | null;
+  sourceEnd: number | null;
+  target: FormalizationProviderTarget | null;
+}
+
+export interface FormalizationProviderCandidateBase {
+  id: string;
+  providerId: string;
+  kind: string;
+  confidence: number | null;
+  status: FormalizationProviderStatus;
+  selected: boolean;
+  validated: boolean;
+  truthScoring: FormalizationProviderTruthScoring;
+  provenance: FormalizationProviderProvenance;
+}
+
+export interface FormalizationProviderTriple extends FormalizationProviderCandidateBase {
+  kind: 'triple';
+  subject: FormalizationProviderPart;
+  predicate: FormalizationProviderPart;
+  object: FormalizationProviderPart;
+}
+
+export interface FormalizationProviderRoleArgument extends FormalizationProviderPart {
+  id: string;
+  role: string;
+}
+
+export interface FormalizationProviderRole extends FormalizationProviderCandidateBase {
+  kind: 'semantic-role-frame';
+  predicate: FormalizationProviderPart;
+  arguments: FormalizationProviderRoleArgument[];
+}
+
+export interface FormalizationProviderEntityLink
+  extends FormalizationProviderCandidateBase, FormalizationProviderPart {
+  kind: 'entity-link';
+  target: FormalizationProviderTarget | null;
+}
+
+export interface FormalizationProviderGraph extends FormalizationProviderCandidateBase {
+  kind: 'semantic-graph';
+  format: string;
+  text: string;
+  nodes: unknown[];
+  edges: unknown[];
+}
+
+export interface FormalizationProviderDiagnostic {
+  id: string;
+  providerId: string;
+  level: string;
+  message: string;
+}
+
+export interface FormalizationProviderSummary {
+  id: string;
+  name: string;
+  kind: string;
+  sourceType: string;
+  version: string | null;
+  status: FormalizationProviderStatus;
+  retrievedAt: string | null;
+  confidence: number | null;
+  truthScoring: FormalizationProviderTruthScoring;
+  provenance: FormalizationProviderProvenance;
+  diagnostics: FormalizationProviderDiagnostic[];
+  candidateCounts: {
+    triples: number;
+    roles: number;
+    entityLinks: number;
+    graphs: number;
+  };
+}
+
+export interface FormalizationProviderCandidates {
+  type: 'formalization-provider-candidates';
+  version: number;
+  status: 'candidate-only' | 'empty';
+  truthScoring: FormalizationProviderTruthScoring;
+  providers: FormalizationProviderSummary[];
+  triples: FormalizationProviderTriple[];
+  roles: FormalizationProviderRole[];
+  entityLinks: FormalizationProviderEntityLink[];
+  graphs: FormalizationProviderGraph[];
+  diagnostics: FormalizationProviderDiagnostic[];
+}
+
+export interface FormalizationProviderContext {
+  language: string;
+  now?: () => number;
+}
+
+export type FormalizationProviderOutput =
+  | FormalizationProviderCandidates
+  | Record<string, unknown>
+  | Array<Record<string, unknown>>;
+
+export interface FormalizationProvider {
+  id?: string;
+  name?: string;
+  kind?: string;
+  sourceType?: string;
+  version?: string | null;
+  extract(
+    text: string,
+    context: FormalizationProviderContext
+  ): FormalizationProviderOutput | Promise<FormalizationProviderOutput>;
+}
+
 export type TransformationRule =
   | {
       id?: string;
@@ -1089,6 +1237,7 @@ export interface FormalizationCst {
   linkTargetMode: FormalizeLinkTargetMode;
   ast: LinguisticAstNode;
   linguisticMetadata: LinguisticMetadata;
+  providerCandidates: FormalizationProviderCandidates;
   phrases: FormalizationCstPhrase[];
   contexts: FormalizeContext[];
 }
@@ -1110,6 +1259,8 @@ export interface FormalizeOptions {
   preFormalizationRules?: TransformationRule | TransformationRule[];
   afterFormalizationRules?: TransformationRule | TransformationRule[];
   postFormalizationRules?: TransformationRule | TransformationRule[];
+  providers?: FormalizationProvider | FormalizationProvider[];
+  providerOutputs?: FormalizationProviderOutput | FormalizationProviderOutput[];
 }
 
 export interface FormalizeResult {
@@ -1121,6 +1272,7 @@ export interface FormalizeResult {
   contexts: FormalizeContext[];
   mainContext: FormalizeContext | null;
   additionalContexts: FormalizeContext[];
+  providerCandidates: FormalizationProviderCandidates;
   interpretations: FormalizeInterpretation[];
   markdown: string;
   html: string;
@@ -1144,6 +1296,15 @@ export declare function formalizeTextWith(
 export declare function markdownFromFormalizationCst(
   cst: FormalizationCst
 ): string;
+
+export declare function createFixtureFormalizationProvider(
+  fixture: FormalizationProviderOutput
+): FormalizationProvider;
+
+export declare function collectFormalizationProviderCandidates(
+  text: string,
+  options?: Partial<FormalizeOptions>
+): Promise<FormalizationProviderCandidates>;
 
 export declare function extractLinguisticMetadata(
   input: string,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -61,6 +61,11 @@ export {
   resolveLinkTarget as resolveFormalizeLinkTarget,
 } from './formalize.js';
 export {
+  FORMALIZATION_PROVIDER_STATUS,
+  collectFormalizationProviderCandidates,
+  createFixtureFormalizationProvider,
+} from './formalization-providers.js';
+export {
   SOURCE_KIND as FORMALIZE_SOURCES,
   createWikidataSource,
   createWikipediaSource,

--- a/js/src/server.js
+++ b/js/src/server.js
@@ -172,6 +172,7 @@ function formalizeParamsFromPayload(payload) {
     overrideFile: payload.overrideFile ?? '',
     noRepoOverrides: payload.noRepoOverrides === true,
     overrides: payload.overrides,
+    providerOutputs: payload.providerOutputs ?? [],
   };
 }
 
@@ -368,6 +369,7 @@ async function sendFormalize(response, params, ctx) {
     sources,
     overrides: [...repoOverrides, ...userOverrides],
     maxNgramSize: params.maxNgramSize,
+    providerOutputs: params.providerOutputs,
   });
   const stored = await writeCacheEntry(
     ctx.cacheRoot,

--- a/js/tests/fixtures/issue-89/openie-amr-srl-provider.json
+++ b/js/tests/fixtures/issue-89/openie-amr-srl-provider.json
@@ -1,0 +1,59 @@
+{
+  "id": "fixture-openie-amr-srl",
+  "name": "Mock OpenIE AMR SRL provider",
+  "kind": "openie-amr-srl",
+  "sourceType": "nlp-provider",
+  "version": "fixture-1",
+  "status": "candidate",
+  "retrievedAt": "2026-05-26T12:00:00.000Z",
+  "triples": [
+    {
+      "id": "triple-1",
+      "subject": { "text": "Stanford OpenIE", "span": [0, 15] },
+      "predicate": { "text": "extracts", "span": [16, 24] },
+      "object": { "text": "relations", "span": [25, 34] },
+      "confidence": 0.82
+    }
+  ],
+  "roles": [
+    {
+      "id": "role-1",
+      "predicate": { "text": "extracts", "span": [16, 24] },
+      "arguments": [
+        {
+          "role": "ARG0",
+          "text": "Stanford OpenIE",
+          "span": [0, 15]
+        },
+        {
+          "role": "ARG1",
+          "text": "relations",
+          "span": [25, 34]
+        }
+      ],
+      "confidence": 0.78
+    }
+  ],
+  "entityLinks": [
+    {
+      "id": "entity-link-1",
+      "text": "Stanford OpenIE",
+      "span": [0, 15],
+      "target": {
+        "id": "external:stanford-openie",
+        "label": "Stanford OpenIE",
+        "kind": "tool",
+        "sourceUrl": "https://nlp.stanford.edu/software/openie.html"
+      },
+      "confidence": 0.74
+    }
+  ],
+  "graphs": [
+    {
+      "id": "amr-1",
+      "format": "amr",
+      "text": "(e / extract-01 :ARG0 (s / software :name (n / name :op1 \"Stanford\" :op2 \"OpenIE\")) :ARG1 (r / relation))",
+      "confidence": 0.69
+    }
+  ]
+}

--- a/js/tests/integration/issue-89.test.js
+++ b/js/tests/integration/issue-89.test.js
@@ -1,0 +1,186 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'test-anywhere';
+import {
+  createFixtureFormalizationProvider,
+  formalizeTextWith,
+} from '../../src/index.js';
+import { createMetaExpressionServer } from '../../src/server.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL(
+      '../fixtures/issue-89/openie-amr-srl-provider.json',
+      import.meta.url
+    ),
+    'utf8'
+  )
+);
+
+const input = 'Stanford OpenIE extracts relations.';
+
+function emptyJsonResponse() {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    async json() {
+      return {};
+    },
+  });
+}
+
+function candidate(id, label, kind = 'entity') {
+  return {
+    id,
+    label,
+    description: `${label} fixture candidate`,
+    kind,
+    source: 'fixture-source',
+    sourceUrl: `https://example.test/${id}`,
+    matchText: label,
+    score: 10,
+    ngramSize: label.split(/\s+/).length,
+  };
+}
+
+function deterministicSource() {
+  const candidatesByText = new Map([
+    [
+      'stanford openie',
+      [candidate('fixture:stanford-openie', 'Stanford OpenIE')],
+    ],
+    ['extracts', [candidate('fixture:extracts', 'extracts', 'property')]],
+    ['relations', [candidate('fixture:relations', 'relations')]],
+  ]);
+  return {
+    name: 'fixture-source',
+    async searchPhrase(text) {
+      return candidatesByText.get(text.toLowerCase()) ?? [];
+    },
+  };
+}
+
+function serverOverrides() {
+  return [
+    override('Stanford', 'fixture:stanford', 'Stanford'),
+    override('OpenIE', 'fixture:openie', 'OpenIE'),
+    override('extracts', 'fixture:extracts', 'extracts', 'property'),
+    override('relations', 'fixture:relations', 'relations'),
+  ];
+}
+
+function override(phrase, entityId, label, kind = 'entity') {
+  return {
+    phrase,
+    entityId,
+    label,
+    kind,
+    source: 'fixture-override',
+    sourceUrl: `https://example.test/${entityId}`,
+  };
+}
+
+describe('issue 89 - OpenIE AMR SRL formalization providers', () => {
+  it('records provider triples, roles, entity links, and graphs without changing deterministic formalization', async () => {
+    const base = await formalizeTextWith(input, {
+      fetch: () => emptyJsonResponse(),
+      sources: [deterministicSource()],
+      now: () => 0,
+    });
+    const withProvider = await formalizeTextWith(input, {
+      fetch: () => emptyJsonResponse(),
+      sources: [deterministicSource()],
+      providers: [createFixtureFormalizationProvider(fixture)],
+      now: () => 0,
+    });
+
+    expect(withProvider.markdown).toBe(base.markdown);
+    expect(withProvider.interpretations).toEqual(base.interpretations);
+    expect(
+      withProvider.phrases.map((phrase) => phrase.entity?.id ?? null)
+    ).toEqual(base.phrases.map((phrase) => phrase.entity?.id ?? null));
+    expect(withProvider.providerCandidates.providers[0].id).toBe(fixture.id);
+    expect(withProvider.providerCandidates.triples[0].status).toBe('candidate');
+    expect(withProvider.providerCandidates.triples[0].truthScoring).toEqual({
+      included: false,
+      eligible: false,
+      reason:
+        'Provider output is a candidate formalization and is not evidence until selected or validated.',
+    });
+    expect(withProvider.providerCandidates.roles[0].arguments.length).toBe(2);
+    expect(withProvider.providerCandidates.entityLinks[0].target.id).toBe(
+      'external:stanford-openie'
+    );
+    expect(withProvider.cst.providerCandidates.graphs[0].format).toBe('amr');
+    expect(
+      withProvider.linksNetwork.links.some(
+        (link) =>
+          link.role === 'provider-candidate-triple' &&
+          link.provenance.sourceType === 'nlp-provider'
+      )
+    ).toBe(true);
+  });
+
+  it('accepts mocked provider output through HTTP /formalize without treating it as verified evidence', async () => {
+    const started = await startServer();
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${started.port}/formalize`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            input,
+            format: 'json',
+            maxNgramSize: 1,
+            noRepoOverrides: true,
+            overrides: serverOverrides(),
+            providerOutputs: [fixture],
+          }),
+        }
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.providerCandidates.providers[0].kind).toBe(
+        'openie-amr-srl'
+      );
+      expect(payload.providerCandidates.entityLinks[0].status).toBe(
+        'candidate'
+      );
+      expect(
+        payload.providerCandidates.entityLinks[0].truthScoring.included
+      ).toBe(false);
+      expect(
+        payload.phrases.map((phrase) => phrase.entity?.source ?? null)
+      ).toEqual([
+        'fixture-override',
+        'fixture-override',
+        'fixture-override',
+        'fixture-override',
+      ]);
+      expect(payload.markdown).toContain('fixture:stanford');
+      expect(Object.hasOwn(payload, 'supportingEvidence')).toBe(false);
+      expect(Object.hasOwn(payload, 'refutingEvidence')).toBe(false);
+    } finally {
+      await stopServer(started.server);
+    }
+  });
+});
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const server = createMetaExpressionServer({
+      cacheRoot: `.cache/issue-89-test-${process.pid}`,
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}


### PR DESCRIPTION
Fixes #89

## Summary

- Adds a candidate-only formalization provider layer for OpenIE triples, SRL role frames, entity links, and AMR/semantic graph records.
- Threads provider candidates through `formalizeTextWith()`, `/formalize` `providerOutputs`, the formalization CST, Links Network records, public exports, and TypeScript declarations.
- Keeps provider output out of truth scoring until downstream selection or validation, and documents that unsupported provider output remains partial rather than verified evidence.
- Adds a mocked OpenIE/AMR/SRL fixture and regression coverage for both the library API and HTTP `/formalize` route.

## Reproduction

Before this change there was no provider interface or `/formalize` payload path for OpenIE/AMR/SRL-style output, so the issue regression failed on the missing `createFixtureFormalizationProvider` export. The new regression uses `js/tests/fixtures/issue-89/openie-amr-srl-provider.json` to prove provider output can be attached without changing deterministic formalization results or adding evidence fields.

## Verification

- `node --test js/tests/integration/issue-89.test.js`
- `npm test`
- `npm run check`
