### PR TITLE
feat: add document-level originality reports

### DIFF
--- a/.changeset/issue-90-originality-report.md
+++ b/.changeset/issue-90-originality-report.md
@@ -1,0 +1,7 @@
+---
+'meta-expression': minor
+---
+
+Add document-level `/uniqueness` originality reports with source spans, match
+strengths, source grouping, exclusion metadata, and a fixture covering exact and
+semantic-similarity matches.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
+# Updated: 2026-05-26T06:10:15.711Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
-# Updated: 2026-05-26T06:10:15.711Z

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ Routes:
 - `GET /uniquness?input=...` and `POST /uniquness` as compatibility aliases
   for the issue title typo.
 
+The JSON `/uniqueness` response keeps the existing `summary` and `statements`
+score fields, and also includes an `originalityReport` with document-level
+source groups, input/source spans, match strengths, source URLs, and exclusion
+metadata for quoted or reference-list text.
+
 ## Static Web Prototype
 
 Serve the repository root and open [`web/index.html`](web/index.html):

--- a/docs/case-studies/issue-90/README.md
+++ b/docs/case-studies/issue-90/README.md
@@ -1,0 +1,25 @@
+# Issue #90: document-level originality reports
+
+> Pull request: [#102](https://github.com/link-assistant/meta-expression/pull/102).
+
+Issue #90 extends the existing `/uniqueness` statement scoring into a
+document-level originality report. The implementation keeps the current summary,
+statement, Markdown, HTML, and Links Notation outputs, while adding structured
+report data for matched sources, source spans, match strengths, and exclusions.
+
+## Artifacts
+
+- [`REQUIREMENTS.md`](./REQUIREMENTS.md) records the acceptance criteria.
+- [`js/tests/fixtures/issue-90-originality-document.json`](../../../js/tests/fixtures/issue-90-originality-document.json)
+  is the document-level originality fixture.
+- [`js/tests/integration/issue-90-originality-report.test.js`](../../../js/tests/integration/issue-90-originality-report.test.js)
+  verifies the report shape.
+
+## Outcome
+
+- `/uniqueness` JSON now includes `originalityReport`.
+- Report matches include input spans, source spans, source URLs, match kind, and
+  match strength.
+- Quoted text and reference sections are listed as exclusions.
+- Existing `summary`, `statements`, `html`, `markdown`, and `linksNotation`
+  fields remain available.

--- a/docs/case-studies/issue-90/REQUIREMENTS.md
+++ b/docs/case-studies/issue-90/REQUIREMENTS.md
@@ -1,0 +1,30 @@
+# Requirements for issue #90
+
+> Parent: [#71](https://github.com/link-assistant/meta-expression/issues/71)
+> and [#58](https://github.com/link-assistant/meta-expression/issues/58).
+
+## R90.1 Document-level originality report
+
+`/uniqueness` must return a document-level originality report that groups
+matched sources and lists each matched passage.
+
+## R90.2 Matched-source spans
+
+Every report match must carry the input span, source URL, source span, match
+kind, and numeric match strength.
+
+## R90.3 Exclusion metadata
+
+The report must include exclusion metadata for text that is reported but not
+counted toward document originality scoring, including quoted text and
+reference-list sections.
+
+## R90.4 Document fixture
+
+Automated coverage must include a document-level fixture with at least two exact
+matched passages and one paraphrase or semantic-similarity match.
+
+## R90.5 Backward-compatible score shape
+
+Existing consumers that read the top-level `/uniqueness` summary and per
+statement score fields must continue to work.

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1856,7 +1856,36 @@ export interface UniquenessSource {
   search(
     statement: UniquenessSearchStatement,
     ctx: UniquenessSearchContext
-  ): Promise<UniquenessMatch[]>;
+  ): Promise<UniquenessSourceMatch[]>;
+}
+
+export interface UniquenessSpan {
+  start: number;
+  end: number;
+  text: string;
+}
+
+export interface UniquenessExclusion {
+  id: string;
+  ruleId: string;
+  reason: string;
+  span: UniquenessSpan;
+}
+
+export interface UniquenessSourceMatch {
+  sourceId?: string;
+  sourceLabel?: string;
+  title?: string;
+  url?: string | null;
+  sourceUrl?: string | null;
+  snippet?: string;
+  sourceText?: string;
+  sourceSpan?: UniquenessSpan | null;
+  score?: number;
+  matchStrength?: number;
+  strength?: number;
+  matchKind?: string;
+  inputSpan?: UniquenessSpan;
 }
 
 export interface UniquenessMatch {
@@ -1864,9 +1893,16 @@ export interface UniquenessMatch {
   sourceLabel: string;
   title: string;
   url: string | null;
+  sourceUrl: string | null;
   snippet: string;
+  sourceText: string;
+  sourceSpan: UniquenessSpan | null;
   score: number;
+  matchStrength: number;
   matchKind: string;
+  inputSpan: UniquenessSpan;
+  excluded: boolean;
+  exclusion: UniquenessExclusion | null;
 }
 
 export interface UniquenessStatement {
@@ -1879,6 +1915,7 @@ export interface UniquenessStatement {
   uniqueness: number;
   suggestedAction: UniquenessSuggestedAction;
   matches: UniquenessMatch[];
+  exclusions: UniquenessExclusion[];
   sourceErrors: Array<{
     sourceId: string;
     sourceLabel: string;
@@ -1897,14 +1934,74 @@ export interface UniquenessSummary {
   averageUniqueness: number | null;
 }
 
+export interface OriginalityReportMatch {
+  id: string;
+  statementId: string;
+  statementText: string;
+  sourceId: string;
+  sourceLabel: string;
+  sourceTitle: string;
+  sourceUrl: string | null;
+  matchKind: string;
+  score: number;
+  strength: number;
+  matchStrength: number;
+  inputSpan: UniquenessSpan;
+  sourceSpan: UniquenessSpan | null;
+  excluded: boolean;
+  exclusion: UniquenessExclusion | null;
+}
+
+export interface OriginalityReportSource {
+  sourceId: string;
+  sourceLabel: string;
+  sourceTitle: string;
+  sourceUrl: string | null;
+  matchCount: number;
+  excludedMatchCount: number;
+  strongestMatch: number;
+  averageStrength: number;
+}
+
+export interface OriginalityReport {
+  kind: 'document-originality-report';
+  checkedAt: string;
+  document: {
+    textLength: number;
+    statementCount: number;
+  };
+  overallExistingLikelihood: number;
+  overallUniqueness: number;
+  averageExistingLikelihood: number | null;
+  averageUniqueness: number | null;
+  scoredMatchCount: number;
+  excludedMatchCount: number;
+  matchedSources: OriginalityReportSource[];
+  matches: OriginalityReportMatch[];
+  exclusions: UniquenessExclusion[];
+}
+
 export interface UniquenessResult {
   status: 'checked';
   text: string;
+  existingLikelihood: number | null;
+  uniqueness: number | null;
   summary: UniquenessSummary;
   statements: UniquenessStatement[];
+  originalityReport: OriginalityReport;
   html: string;
   markdown: string;
   linksNotation: string;
+}
+
+export interface UniquenessConfiguredExclusion {
+  id?: string;
+  ruleId?: string;
+  reason?: string;
+  start?: number;
+  end?: number;
+  text?: string;
+  span?: Partial<UniquenessSpan>;
 }
 
 export interface UniquenessOptions {
@@ -1912,6 +2009,9 @@ export interface UniquenessOptions {
   language?: string;
   limit?: number;
   sources?: UniquenessSource[];
+  exclusions?: UniquenessConfiguredExclusion[];
+  excludeQuotedText?: boolean;
+  excludeReferences?: boolean;
   crossref?: {
     mailto?: string;
   };

--- a/js/src/uniqueness.js
+++ b/js/src/uniqueness.js
@@ -45,6 +45,7 @@ export function createWikipediaUniquenessSource(options = {}) {
           snippet,
           score: exact ? 0.92 : similarity * 0.65,
           matchKind: exact ? 'exact' : 'related',
+          query: statement.query,
         });
       });
     },
@@ -82,6 +83,7 @@ export function createOpenAlexUniquenessSource() {
           snippet: [authors, work.publication_year].filter(Boolean).join(' - '),
           score,
           matchKind: exact ? 'exact-title' : 'similar-work',
+          query: statement.query,
         });
       });
     },
@@ -112,6 +114,7 @@ export function createCrossrefUniquenessSource(options = {}) {
           snippet: item['container-title']?.[0] ?? item.DOI ?? '',
           score: exact ? 0.86 : similarity * 0.68,
           matchKind: exact ? 'exact-title' : 'bibliographic-match',
+          query: statement.query,
         });
       });
     },
@@ -150,6 +153,7 @@ export function createDuckDuckGoUniquenessSource() {
           snippet: entry.snippet ?? '',
           score: exact ? 0.78 : similarity * 0.62,
           matchKind: exact ? 'instant-answer-exact' : 'instant-answer',
+          query: statement.query,
         });
       });
     },
@@ -163,11 +167,13 @@ export async function searchTextUniqueness(input, options = {}) {
   const fetchImpl = options.fetch ?? globalThis.fetch?.bind(globalThis);
   const limit = clampInteger(options.limit ?? defaultLimit, 1, 10);
   const now = normalizeNow(options.now);
+  const exclusions = collectExclusions(text, options);
 
   const statements = [];
   for (const [index, statement] of detected.entries()) {
     statements.push(
       await searchStatementUniqueness(statement, index, {
+        exclusions,
         fetch: fetchImpl,
         limit,
         now,
@@ -176,7 +182,7 @@ export async function searchTextUniqueness(input, options = {}) {
     );
   }
 
-  return buildUniquenessResult(text, statements);
+  return buildUniquenessResult(text, statements, exclusions, now);
 }
 
 async function searchStatementUniqueness(statement, index, ctx) {
@@ -188,7 +194,16 @@ async function searchStatementUniqueness(statement, index, ctx) {
   );
   const matches = sourceResults
     .flatMap((result) => result.matches)
+    .map((match) => applyMatchExclusion(match, statement, ctx.exclusions))
     .sort((a, b) => b.score - a.score);
+  const exclusions = ctx.exclusions.filter((exclusion) =>
+    rangesOverlap(
+      statement.start,
+      statement.end,
+      exclusion.span.start,
+      exclusion.span.end
+    )
+  );
   const sourceErrors = sourceResults
     .filter((result) => result.error)
     .map(({ sourceId, sourceLabel, error }) => ({
@@ -210,6 +225,7 @@ async function searchStatementUniqueness(statement, index, ctx) {
     uniqueness,
     suggestedAction: suggestedAction(existingLikelihood),
     matches,
+    exclusions,
     sourceErrors,
     checkedAt: ctx.now,
     color: colorForUniqueness(uniqueness),
@@ -225,7 +241,10 @@ async function searchSource(source, statement, ctx) {
     return {
       sourceId: source.id,
       sourceLabel: source.label,
-      matches: matches.filter((match) => match?.score > 0),
+      matches: (matches ?? [])
+        .filter(Boolean)
+        .map((match) => normalizeSearchMatch(match, statement, source))
+        .filter((match) => match.score > 0),
     };
   } catch (error) {
     return {
@@ -237,13 +256,23 @@ async function searchSource(source, statement, ctx) {
   }
 }
 
-function buildUniquenessResult(text, statements) {
+function buildUniquenessResult(text, statements, exclusions, checkedAt) {
   const summary = summarizeStatements(statements);
+  const originalityReport = buildOriginalityReport(
+    text,
+    statements,
+    summary,
+    exclusions,
+    checkedAt
+  );
   return {
     status: 'checked',
     text,
+    existingLikelihood: summary.averageExistingLikelihood,
+    uniqueness: summary.averageUniqueness,
     summary,
     statements,
+    originalityReport,
     html: renderUniquenessHtml(text, statements),
     markdown: renderUniquenessMarkdown(statements, summary),
     linksNotation: renderUniquenessLino(text, statements, summary),
@@ -314,10 +343,15 @@ function renderUniquenessMarkdown(statements, summary) {
       )} unique [${statement.suggestedAction}]: ${statement.text}`
     );
     for (const match of statement.matches.slice(0, 3)) {
+      const excluded = match.excluded
+        ? `, excluded: ${match.exclusion.reason}`
+        : '';
       lines.push(
         `  - ${match.sourceLabel} (${match.matchKind}, ${formatPercent(
           match.score
-        )}): ${match.title}${match.url ? ` - ${match.url}` : ''}`
+        )}${excluded}): ${match.title}${
+          match.sourceUrl ? ` - ${match.sourceUrl}` : ''
+        }`
       );
     }
   }
@@ -340,10 +374,17 @@ function renderUniquenessLino(text, statements, summary) {
         suggestedAction: statement.suggestedAction,
         matches: statement.matches.map((match) => ({
           sourceId: match.sourceId,
+          sourceLabel: match.sourceLabel,
           title: match.title,
           url: match.url,
+          sourceUrl: match.sourceUrl,
           score: match.score,
+          matchStrength: match.matchStrength,
           matchKind: match.matchKind,
+          inputSpan: match.inputSpan,
+          sourceSpan: match.sourceSpan,
+          excluded: match.excluded,
+          exclusion: match.exclusion,
         })),
       })),
     },
@@ -359,15 +400,331 @@ function buildMatch({
   snippet,
   score,
   matchKind,
+  sourceText,
+  sourceSpan,
+  query,
 }) {
+  const normalizedScore = clamp(Number(score), 0, 1);
+  const normalizedTitle = normalizeWhitespace(title);
+  const normalizedSnippet = normalizeWhitespace(snippet);
+  const normalizedSourceText = normalizeWhitespace(
+    sourceText ?? (normalizedSnippet || normalizedTitle)
+  );
   return {
     sourceId,
     sourceLabel,
-    title: normalizeWhitespace(title),
+    title: normalizedTitle,
     url: url || null,
-    snippet: normalizeWhitespace(snippet),
-    score: clamp(score, 0, 1),
+    sourceUrl: url || null,
+    snippet: normalizedSnippet,
+    sourceText: normalizedSourceText,
+    sourceSpan: normalizeSourceSpan(sourceSpan, normalizedSourceText, query),
+    score: normalizedScore,
+    matchStrength: normalizedScore,
     matchKind,
+  };
+}
+
+function normalizeSearchMatch(match, statement, source) {
+  const url = match.url ?? match.sourceUrl ?? null;
+  const title = normalizeWhitespace(match.title);
+  const snippet = normalizeWhitespace(match.snippet);
+  const sourceText = normalizeWhitespace(
+    match.sourceText ?? (snippet || title)
+  );
+  const score = clamp(
+    Number(match.score ?? match.matchStrength ?? match.strength ?? 0),
+    0,
+    1
+  );
+  return {
+    ...match,
+    sourceId: String(match.sourceId ?? source.id),
+    sourceLabel: String(match.sourceLabel ?? source.label),
+    title,
+    url,
+    sourceUrl: url,
+    snippet,
+    sourceText,
+    sourceSpan: normalizeSourceSpan(
+      match.sourceSpan,
+      sourceText,
+      statement.query
+    ),
+    score,
+    matchStrength: score,
+    matchKind: String(match.matchKind ?? 'source-match'),
+    inputSpan: normalizeInputSpan(match.inputSpan, statement),
+    excluded: false,
+    exclusion: null,
+  };
+}
+
+function normalizeInputSpan(span, statement) {
+  if (
+    span &&
+    Number.isFinite(Number(span.start)) &&
+    Number.isFinite(Number(span.end))
+  ) {
+    const start = Number(span.start);
+    const end = Number(span.end);
+    return {
+      start,
+      end,
+      text: String(span.text ?? statement.text),
+    };
+  }
+  return {
+    start: statement.start,
+    end: statement.end,
+    text: statement.text,
+  };
+}
+
+function normalizeSourceSpan(span, sourceText, query) {
+  if (
+    span &&
+    Number.isFinite(Number(span.start)) &&
+    Number.isFinite(Number(span.end))
+  ) {
+    const start = Number(span.start);
+    const end = Number(span.end);
+    return {
+      start,
+      end,
+      text: String(span.text ?? sourceText.slice(start, end)),
+    };
+  }
+  return inferSourceSpan(sourceText, query);
+}
+
+function inferSourceSpan(sourceText, query) {
+  const text = String(sourceText ?? '');
+  if (!text) {
+    return null;
+  }
+  const needle = normalizeWhitespace(query);
+  if (needle) {
+    const index = text.toLowerCase().indexOf(needle.toLowerCase());
+    if (index >= 0) {
+      return {
+        start: index,
+        end: index + needle.length,
+        text: text.slice(index, index + needle.length),
+      };
+    }
+  }
+  const end = Math.min(text.length, 240);
+  return {
+    start: 0,
+    end,
+    text: text.slice(0, end),
+  };
+}
+
+function applyMatchExclusion(match, statement, exclusions) {
+  const exclusion = exclusions.find((candidate) =>
+    rangesOverlap(
+      statement.start,
+      statement.end,
+      candidate.span.start,
+      candidate.span.end
+    )
+  );
+  return {
+    ...match,
+    excluded: Boolean(exclusion),
+    exclusion: exclusion ? summarizeExclusion(exclusion) : null,
+  };
+}
+
+function buildOriginalityReport(
+  text,
+  statements,
+  summary,
+  exclusions,
+  checkedAt
+) {
+  const matches = [];
+  for (const statement of statements) {
+    for (const match of statement.matches) {
+      matches.push({
+        id: `match-${matches.length + 1}`,
+        statementId: statement.id,
+        statementText: statement.text,
+        sourceId: match.sourceId,
+        sourceLabel: match.sourceLabel,
+        sourceTitle: match.title,
+        sourceUrl: match.sourceUrl,
+        matchKind: match.matchKind,
+        score: match.score,
+        strength: match.matchStrength,
+        matchStrength: match.matchStrength,
+        inputSpan: match.inputSpan,
+        sourceSpan: match.sourceSpan,
+        excluded: match.excluded,
+        exclusion: match.exclusion,
+      });
+    }
+  }
+  const scoredMatches = matches.filter((match) => !match.excluded);
+  const overallExistingLikelihood = combineLikelihoods(
+    scoredMatches.map((match) => match.strength)
+  );
+  return {
+    kind: 'document-originality-report',
+    checkedAt,
+    document: {
+      textLength: text.length,
+      statementCount: statements.length,
+    },
+    overallExistingLikelihood,
+    overallUniqueness: clamp(1 - overallExistingLikelihood, 0, 1),
+    averageExistingLikelihood: summary.averageExistingLikelihood,
+    averageUniqueness: summary.averageUniqueness,
+    scoredMatchCount: scoredMatches.length,
+    excludedMatchCount: matches.length - scoredMatches.length,
+    matchedSources: summarizeMatchedSources(matches),
+    matches,
+    exclusions: exclusions.map(summarizeExclusion),
+  };
+}
+
+function summarizeMatchedSources(matches) {
+  const bySource = new Map();
+  for (const match of matches) {
+    const key = [match.sourceId, match.sourceUrl, match.sourceTitle].join('|');
+    if (!bySource.has(key)) {
+      bySource.set(key, {
+        sourceId: match.sourceId,
+        sourceLabel: match.sourceLabel,
+        sourceTitle: match.sourceTitle,
+        sourceUrl: match.sourceUrl,
+        matchCount: 0,
+        excludedMatchCount: 0,
+        strongestMatch: 0,
+        averageStrength: 0,
+      });
+    }
+    const source = bySource.get(key);
+    source.matchCount += 1;
+    if (match.excluded) {
+      source.excludedMatchCount += 1;
+    }
+    source.strongestMatch = Math.max(source.strongestMatch, match.strength);
+    source.averageStrength += match.strength;
+  }
+  return [...bySource.values()].map((source) => ({
+    ...source,
+    averageStrength:
+      source.matchCount === 0 ? 0 : source.averageStrength / source.matchCount,
+  }));
+}
+
+function collectExclusions(text, options) {
+  const configured = Array.isArray(options.exclusions)
+    ? options.exclusions.map((exclusion, index) =>
+        normalizeConfiguredExclusion(exclusion, index, text)
+      )
+    : [];
+  const quoted =
+    options.excludeQuotedText === false ? [] : detectQuotedExclusionSpans(text);
+  const references =
+    options.excludeReferences === false
+      ? []
+      : detectReferenceExclusionSpans(text);
+  return [...configured, ...quoted, ...references].filter(Boolean);
+}
+
+function normalizeConfiguredExclusion(exclusion, index, text) {
+  const span = normalizeConfiguredExclusionSpan(exclusion, text);
+  if (!span) {
+    return null;
+  }
+  return {
+    id: String(exclusion.id ?? `configured-exclusion-${index + 1}`),
+    ruleId: String(exclusion.ruleId ?? 'configured-exclusion'),
+    reason: String(exclusion.reason ?? 'Configured text exclusion.'),
+    span,
+  };
+}
+
+function normalizeConfiguredExclusionSpan(exclusion, text) {
+  const start = Number(exclusion?.start ?? exclusion?.span?.start);
+  const end = Number(exclusion?.end ?? exclusion?.span?.end);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return null;
+  }
+  return {
+    start,
+    end,
+    text: String(
+      exclusion.text ?? exclusion.span?.text ?? text.slice(start, end)
+    ),
+  };
+}
+
+function detectQuotedExclusionSpans(text) {
+  const exclusions = [];
+  let quoteStart = -1;
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== '"') {
+      continue;
+    }
+    if (quoteStart === -1) {
+      quoteStart = index + 1;
+      continue;
+    }
+    const spanText = text.slice(quoteStart, index);
+    if (spanText.trim()) {
+      exclusions.push({
+        id: `quoted-text-${exclusions.length + 1}`,
+        ruleId: 'quoted-text',
+        reason:
+          'Quoted text is reported but excluded from document originality scoring.',
+        span: {
+          start: quoteStart,
+          end: index,
+          text: spanText,
+        },
+      });
+    }
+    quoteStart = -1;
+  }
+  return exclusions;
+}
+
+function detectReferenceExclusionSpans(text) {
+  const match =
+    /(^|\n)\s*(references|bibliography|works cited)\s*:?\s*(\n|$)/iu.exec(text);
+  if (!match) {
+    return [];
+  }
+  const start = match.index + match[0].length;
+  if (start >= text.length) {
+    return [];
+  }
+  return [
+    {
+      id: 'references-section-1',
+      ruleId: 'references-section',
+      reason:
+        'Reference-list text is reported but excluded from document originality scoring.',
+      span: {
+        start,
+        end: text.length,
+        text: text.slice(start),
+      },
+    },
+  ];
+}
+
+function summarizeExclusion(exclusion) {
+  return {
+    id: exclusion.id,
+    ruleId: exclusion.ruleId,
+    reason: exclusion.reason,
+    span: exclusion.span,
   };
 }
 
@@ -523,6 +880,10 @@ function dataValue(value) {
 function clampInteger(value, min, max) {
   const parsed = Number(value);
   return Math.min(max, Math.max(min, Number.isFinite(parsed) ? parsed : min));
+}
+
+function rangesOverlap(leftStart, leftEnd, rightStart, rightEnd) {
+  return leftStart < rightEnd && rightStart < leftEnd;
 }
 
 function clamp(value, min, max) {

--- a/js/tests/fixtures/issue-90-originality-document.json
+++ b/js/tests/fixtures/issue-90-originality-document.json
@@ -1,0 +1,69 @@
+{
+  "input": "Mars has two small moons, Phobos and Deimos. The boiling point of water is 100 degrees Celsius at sea level. A person is having a meal. \"Hawaii is a state.\"",
+  "matches": [
+    {
+      "query": "Mars has two small moons, Phobos and Deimos",
+      "sourceId": "planetary-reference",
+      "sourceLabel": "Planetary Reference",
+      "title": "Mars moons overview",
+      "url": "https://example.test/sources/mars-moons",
+      "snippet": "Mars has two small moons, Phobos and Deimos.",
+      "sourceText": "Mars has two small moons, Phobos and Deimos. The larger moon is Phobos.",
+      "sourceSpan": {
+        "start": 0,
+        "end": 43,
+        "text": "Mars has two small moons, Phobos and Deimos"
+      },
+      "score": 0.94,
+      "matchKind": "exact-passage"
+    },
+    {
+      "query": "The boiling point of water is 100 degrees Celsius at sea level",
+      "sourceId": "chemistry-handbook",
+      "sourceLabel": "Chemistry Handbook",
+      "title": "Water boiling point",
+      "url": "https://example.test/sources/water-boiling-point",
+      "snippet": "The boiling point of water is 100 degrees Celsius at sea level.",
+      "sourceText": "At sea level, the boiling point of water is 100 degrees Celsius. The boiling point of water is 100 degrees Celsius at sea level.",
+      "sourceSpan": {
+        "start": 68,
+        "end": 129,
+        "text": "The boiling point of water is 100 degrees Celsius at sea level"
+      },
+      "score": 0.91,
+      "matchKind": "exact-passage"
+    },
+    {
+      "query": "A person is having a meal",
+      "sourceId": "semantic-similarity-fixture",
+      "sourceLabel": "Semantic Similarity Fixture",
+      "title": "STS-B paraphrase pair",
+      "url": "https://example.test/sources/sts-b-meal",
+      "snippet": "A man is eating food.",
+      "sourceText": "A man is eating food while seated at a table.",
+      "sourceSpan": {
+        "start": 0,
+        "end": 21,
+        "text": "A man is eating food."
+      },
+      "score": 0.82,
+      "matchKind": "semantic-similarity"
+    },
+    {
+      "query": "Hawaii is a state",
+      "sourceId": "published-text-sample",
+      "sourceLabel": "Published Text Sample",
+      "title": "Project sample text",
+      "url": "https://example.test/published/hawaii",
+      "snippet": "Hawaii is a state.",
+      "sourceText": "Hawaii is a state.",
+      "sourceSpan": {
+        "start": 0,
+        "end": 18,
+        "text": "Hawaii is a state."
+      },
+      "score": 0.91,
+      "matchKind": "exact-passage"
+    }
+  ]
+}

--- a/js/tests/integration/issue-90-originality-report.test.js
+++ b/js/tests/integration/issue-90-originality-report.test.js
@@ -1,0 +1,83 @@
+import { readFile } from 'node:fs/promises';
+import { describe, it, expect } from 'test-anywhere';
+import { searchTextUniqueness } from '../../src/index.js';
+
+const FIXTURE_PATH = 'js/tests/fixtures/issue-90-originality-document.json';
+
+async function loadFixture() {
+  return JSON.parse(await readFile(FIXTURE_PATH, 'utf8'));
+}
+
+function fixtureSource(matches) {
+  return {
+    id: 'issue-90-fixture',
+    label: 'Issue 90 Fixture',
+    async search(statement) {
+      return matches.filter((match) => match.query === statement.query);
+    },
+  };
+}
+
+describe('issue 90 - document-level originality report', () => {
+  it('returns source spans, strengths, exclusions, and document source groups', async () => {
+    const fixture = await loadFixture();
+    const result = await searchTextUniqueness(fixture.input, {
+      sources: [fixtureSource(fixture.matches)],
+      now: () => '2026-05-26T00:00:00.000Z',
+    });
+
+    expect(result.status).toBe('checked');
+    expect(result.summary.total).toBe(4);
+    expect(result.statements.length).toBe(4);
+    expect(result.existingLikelihood).toBe(
+      result.summary.averageExistingLikelihood
+    );
+    expect(result.uniqueness).toBe(result.summary.averageUniqueness);
+
+    const report = result.originalityReport;
+    expect(report.kind).toBe('document-originality-report');
+    expect(report.matches.length).toBe(4);
+    expect(report.matchedSources.length).toBeGreaterThanOrEqual(3);
+    expect(report.exclusions.length).toBeGreaterThanOrEqual(1);
+    expect(report.scoredMatchCount).toBe(3);
+    expect(report.excludedMatchCount).toBe(1);
+
+    const scored = report.matches.filter((match) => !match.excluded);
+    expect(
+      scored.filter((match) => match.matchKind === 'exact-passage').length
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      scored.some(
+        (match) =>
+          match.matchKind === 'semantic-similarity' && match.strength >= 0.8
+      )
+    ).toBe(true);
+
+    for (const match of report.matches) {
+      expect(match.sourceUrl.startsWith('https://example.test/')).toBe(true);
+      expect(match.strength).toBeGreaterThan(0);
+      expect(match.matchStrength).toBe(match.strength);
+      expect(match.sourceSpan.text.length).toBeGreaterThan(0);
+      expect(
+        fixture.input.slice(match.inputSpan.start, match.inputSpan.end)
+      ).toBe(match.inputSpan.text);
+    }
+
+    const quoteMatch = report.matches.find((match) =>
+      match.inputSpan.text.includes('Hawaii is a state')
+    );
+    expect(quoteMatch.excluded).toBe(true);
+    expect(quoteMatch.exclusion.ruleId).toBe('quoted-text');
+    expect(quoteMatch.exclusion.span.text).toContain('Hawaii is a state.');
+
+    const [statementMatch] = result.statements[0].matches;
+    expect(statementMatch.sourceUrl).toBe(
+      'https://example.test/sources/mars-moons'
+    );
+    expect(statementMatch.matchStrength).toBe(statementMatch.score);
+    expect(statementMatch.inputSpan.text).toBe(result.statements[0].text);
+    expect(statementMatch.sourceSpan.text).toContain(
+      'Mars has two small moons'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #90

## Summary
- Adds document-level `originalityReport` data to `/uniqueness` while keeping existing `summary`, `statements`, `html`, `markdown`, and `linksNotation` response fields.
- Enriches uniqueness matches with input/source spans, source URLs, match strengths, and exclusion metadata for quoted and reference-list text.
- Adds an issue #90 fixture and integration test covering two exact matched passages, one semantic-similarity match, and one excluded quoted passage.
- Adds issue #90 case-study requirements/docs and a minor changeset.

## Reproduction
Before this PR, `/uniqueness` returned statement-level match data but did not expose a document-level originality report with spans, source grouping, or exclusion metadata.

## Testing
- `node --test js/tests/integration/issue-90-originality-report.test.js`
- `node --test js/tests/e2e/issue-27.test.js`
- `node --test js/tests/integration/issue-26-comparable-fixtures.test.js`
- `npm test`
- `npm run check`
- `git diff --check`
- `scripts/check-file-line-limits.sh` (passes; reports existing warning-threshold files, all under 1500-line limit)

No visual screenshots are included because this change only extends the uniqueness/originality data returned by the API and generated text formats.