### PR TITLE
feat: add literature-review evidence workflows

### DIFF
--- a/.changeset/issue-91-literature-review.md
+++ b/.changeset/issue-91-literature-review.md
@@ -1,0 +1,7 @@
+---
+'meta-expression': minor
+---
+
+Add literature-review evidence workflows that turn screened paper metadata,
+excerpts, and support/refute decisions into evidence links with BibTeX, RIS, and
+CSV bibliography exports.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
+# Updated: 2026-05-26T06:39:16.671Z

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Core exports:
 - `exportEvidenceJsonLd(result)` and `exportEvidenceProvJsonLd(result)` export
   `/analyze` and `/check` evidence provenance as JSON-LD and a PROV-O-compatible
   JSON-LD graph while preserving Links Notation output.
+- `reviewClaimAgainstLiterature(fixture)` checks a claim against screened paper
+  metadata/excerpts as normal evidence links, reports literature agreement and
+  uncertainty, and `exportLiteratureBibliography(result, { format })` emits
+  BibTeX, RIS, or CSV bibliography data.
 - `searchTextUniqueness(input, options)` searches detected statements across
   public web and scholarly APIs, returning existing-likelihood scores,
   citation/rewording suggestions, source matches, HTML, Markdown, and Links
@@ -112,6 +116,7 @@ node js/src/cli.js check --input "Earth orbits the Sun." --format claim-review
 node js/src/cli.js check --input "Earth orbits the Sun." --format prov-o
 node js/src/cli.js fact-check --input "Paris is the capital of France." --live
 node js/src/cli.js uniqueness --input "Earth orbits the Sun." --format markdown
+node js/src/cli.js literature-review --fixture js/tests/fixtures/issue-91-literature-review.json --format bibtex
 ```
 
 ## Microservice

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -8,8 +8,10 @@ import {
   analyzeStatementWithLiveEvidence,
   exportEvidenceJsonLd,
   exportEvidenceProvJsonLd,
+  exportLiteratureBibliography,
   naturalizeExpressionWith,
   parsePreferenceProfile,
+  reviewClaimAgainstLiterature,
   serializeLinksNotation,
 } from './index.js';
 import { formalizeTextWith, FORMALIZE_LINK_TARGETS } from './formalize.js';
@@ -105,6 +107,9 @@ export function parseCliArguments(args) {
     },
     '--preference-profile': () => {
       options.profileFile = nextValue();
+    },
+    '--fixture': () => {
+      options.fixtureFile = nextValue();
     },
     '--help': () => {
       options.command = 'help';
@@ -268,6 +273,10 @@ function configureCliYargs({ yargs, getenv }) {
       type: 'string',
       default: getenv('PREFERENCE_PROFILE', ''),
     })
+    .option('fixture', {
+      type: 'string',
+      default: getenv('FIXTURE', ''),
+    })
     .option('help', {
       alias: 'h',
       type: 'boolean',
@@ -331,6 +340,7 @@ function createCliOptions(config) {
     'sourceUrl',
     firstPresent(config.sourceUrl, config.source)
   );
+  assignStringOption(options, 'fixtureFile', config.fixture);
   if (config.help === true) {
     options.command = 'help';
   }
@@ -444,6 +454,9 @@ export function runCli(args = process.argv.slice(2), output = console) {
   if (isUniquenessCommand(options.command)) {
     throw new Error('Use runCliAsync for the uniqueness command.');
   }
+  if (isLiteratureReviewCommand(options.command)) {
+    throw new Error('Use runCliAsync for the literature-review command.');
+  }
 
   const checked = validateCliOptions(options, output);
   if (checked !== null) {
@@ -495,6 +508,9 @@ export async function runCliAsync(
   }
   if (isUniquenessCommand(options.command)) {
     return runUniquenessCommand(options, output);
+  }
+  if (isLiteratureReviewCommand(options.command)) {
+    return runLiteratureReviewCommand(options, output);
   }
 
   const analysis = options.live
@@ -719,6 +735,22 @@ async function runUniquenessCommand(options, output) {
   return emitUniquenessResult(options, output, result);
 }
 
+async function runLiteratureReviewCommand(options, output) {
+  const fixture = options.fixtureFile
+    ? await readJsonFile(options.fixtureFile)
+    : parseLiteratureReviewInput(options.input);
+  const result = reviewClaimAgainstLiterature(fixture);
+  return emitLiteratureReviewResult(options, output, result);
+}
+
+function parseLiteratureReviewInput(input) {
+  const trimmed = String(input ?? '').trim();
+  if (!trimmed) {
+    throw new Error('literature-review requires JSON input or --fixture.');
+  }
+  return JSON.parse(trimmed);
+}
+
 function resolveCliLinkTargetMode(token) {
   if (!token) {
     return FORMALIZE_LINK_TARGETS.WIKIPEDIA;
@@ -750,6 +782,8 @@ function validateCliOptions(options, output) {
     'fact-check',
     'uniqueness',
     'uniquness',
+    'literature-review',
+    'lit-review',
   ];
   if (!supportedCommands.includes(options.command)) {
     output.error(`Unsupported command: ${options.command}`);
@@ -758,6 +792,14 @@ function validateCliOptions(options, output) {
   }
 
   if (options.command === 'translation-quality') {
+    return null;
+  }
+  if (isLiteratureReviewCommand(options.command)) {
+    if (!options.fixtureFile && !options.input) {
+      output.error('literature-review requires --fixture <file.json>.');
+      output.error(helpText());
+      return 1;
+    }
     return null;
   }
 
@@ -851,6 +893,39 @@ function emitUniquenessResult(options, output, result) {
   return 0;
 }
 
+function emitLiteratureReviewResult(options, output, result) {
+  if (isLiteratureBibliographyFormat(options.format)) {
+    output.log(
+      exportLiteratureBibliography(result, { format: options.format })
+    );
+    return 0;
+  }
+  if (options.format === 'markdown' || options.format === 'md') {
+    output.log(formatLiteratureReviewMarkdown(result));
+    return 0;
+  }
+  output.log(JSON.stringify(result, null, 2));
+  return 0;
+}
+
+function formatLiteratureReviewMarkdown(result) {
+  const lines = [
+    `# Literature review: ${result.claim.text}`,
+    '',
+    `Agreement: ${result.summary.agreement.label}`,
+    `Support weight: ${result.summary.agreement.supportWeight}`,
+    `Refute weight: ${result.summary.agreement.refuteWeight}`,
+    `Uncertainty: ${result.summary.agreement.uncertainty}`,
+    '',
+  ];
+  for (const paper of result.papers) {
+    lines.push(
+      `- ${paper.citationKey}: ${paper.decision.label} (${paper.decision.weight}) - ${paper.title}`
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
 function isCheckCommand(command) {
   return command === 'check' || command === 'fact-check';
 }
@@ -885,6 +960,14 @@ function isNaturalizeCommand(command) {
   return command === 'naturalize' || command === 'deformalize';
 }
 
+function isLiteratureReviewCommand(command) {
+  return command === 'literature-review' || command === 'lit-review';
+}
+
+function isLiteratureBibliographyFormat(format) {
+  return ['bibtex', 'bib', 'ris', 'csv'].includes(format);
+}
+
 function helpText() {
   return `Usage:
   meta-expression analyze "1 + 1 = 2"
@@ -903,6 +986,7 @@ function helpText() {
   meta-expression check --input "Earth orbits the Sun." --score wikidata-structured-claim=0.7
   meta-expression fact-check --input "Paris is the capital of France." --live
   meta-expression uniqueness --input "Earth orbits the Sun." --format markdown
+  meta-expression literature-review --fixture js/tests/fixtures/issue-91-literature-review.json --format bibtex
 
 Commands:
   analyze     Run the disambiguation/evaluation prototype.
@@ -915,6 +999,8 @@ Commands:
   check       Color detected statements by correctness.
   fact-check  Alias for check.
   uniqueness  Search public sources for prior exact or similar statements.
+  literature-review
+              Check one claim against a screened paper fixture and export bibliography data.
 
 Options:
   -i, --input <text>             Statement text
@@ -943,6 +1029,7 @@ Options:
                                  check/fact-check: override evidence scoring
   --source, --source-url <url>    check/fact-check: source URL for ClaimReview
                                  exports
+  --fixture <file.json>           literature-review: screened paper fixture
   -h, --help                     Show this help`;
 }
 

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1799,6 +1799,101 @@ export interface ClaimReviewOptions {
   statementIndex?: number;
 }
 
+export type LiteratureDecisionPolarity = 'support' | 'refute' | 'uncertain';
+
+export interface LiteratureAuthor {
+  given: string | null;
+  family: string | null;
+  literal?: string | null;
+}
+
+export interface LiteratureExcerpt {
+  id: string;
+  section: string | null;
+  page: string | null;
+  text: string;
+}
+
+export interface LiteratureDecision {
+  polarity: LiteratureDecisionPolarity;
+  weight: number;
+  label: string;
+  rationale: string | null;
+}
+
+export interface LiteraturePaper {
+  id: string;
+  citationKey: string;
+  type: string;
+  title: string;
+  authors: LiteratureAuthor[];
+  journal: string | null;
+  publisher: string | null;
+  year: string;
+  date: string | null;
+  volume: string | null;
+  issue: string | null;
+  pages: string | null;
+  doi: string | null;
+  pmid: string | null;
+  url: string | null;
+  abstract?: string | null;
+  decision: LiteratureDecision;
+  excerpts: LiteratureExcerpt[];
+}
+
+export interface LiteratureReviewInput {
+  claim: string | { text: string; domain?: string };
+  query?: Record<string, unknown>;
+  screenedAt?: string | number | Date;
+  screeningMethod?: string;
+  papers: Array<Partial<LiteraturePaper> & Record<string, unknown>>;
+}
+
+export interface LiteratureAgreementSummary {
+  label:
+    | 'supports'
+    | 'refutes'
+    | 'mixed-support'
+    | 'mixed-refute'
+    | 'uncertain';
+  supportWeight: number;
+  refuteWeight: number;
+  rawBalance: number | null;
+  uncertainty: number;
+}
+
+export interface LiteratureReviewResult {
+  status: 'reviewed';
+  kind: 'literature-review';
+  claim: { text: string; domain: string | null };
+  query: Record<string, unknown> | null;
+  screenedAt: string;
+  screeningMethod: string;
+  papers: LiteraturePaper[];
+  evidenceItems: EvidenceItem[];
+  checked: CheckResult;
+  summary: {
+    totalPapers: number;
+    screenedPapers: number;
+    supportingPapers: number;
+    refutingPapers: number;
+    uncertainPapers: number;
+    evidenceLinks: number;
+    confidence: number | null;
+    agreement: LiteratureAgreementSummary;
+  };
+  bibliography: {
+    papers: Array<Omit<LiteraturePaper, 'abstract' | 'decision' | 'excerpts'>>;
+  };
+}
+
+export interface LiteratureReviewOptions extends AnalysisOptions {
+  screenedAt?: string | number | Date;
+}
+
+export type LiteratureBibliographyFormat = 'bibtex' | 'bib' | 'ris' | 'csv';
+
 export interface EvidenceProvenanceExportOptions {
   baseId?: string;
   exportedAt?: string | number | Date;
@@ -2072,6 +2167,33 @@ export declare function exportClaimReviewJsonLd(
   input: CheckResult | CheckStatement | StatementAnalysis,
   options?: ClaimReviewOptions
 ): Record<string, unknown>;
+
+export declare function reviewClaimAgainstLiterature(
+  input: LiteratureReviewInput,
+  options?: LiteratureReviewOptions
+): LiteratureReviewResult;
+
+export declare function createLiteratureEvidenceItems(
+  input: LiteratureReviewInput,
+  options?: LiteratureReviewOptions
+): EvidenceItem[];
+
+export declare function exportLiteratureBibliography(
+  input: LiteratureReviewResult | LiteratureReviewInput | LiteraturePaper[],
+  options?: { format?: LiteratureBibliographyFormat }
+): string;
+
+export declare function exportLiteratureBibTeX(
+  input: LiteratureReviewResult | LiteratureReviewInput | LiteraturePaper[]
+): string;
+
+export declare function exportLiteratureRis(
+  input: LiteratureReviewResult | LiteratureReviewInput | LiteraturePaper[]
+): string;
+
+export declare function exportLiteratureCsv(
+  input: LiteratureReviewResult | LiteratureReviewInput | LiteraturePaper[]
+): string;
 
 export declare function exportEvidenceJsonLd(
   input: StatementAnalysis | CheckResult,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -115,6 +115,14 @@ export {
   exportEvidenceProvJsonLd,
 } from './provenance-jsonld.js';
 export {
+  createLiteratureEvidenceItems,
+  exportLiteratureBibliography,
+  exportLiteratureBibTeX,
+  exportLiteratureCsv,
+  exportLiteratureRis,
+  reviewClaimAgainstLiterature,
+} from './literature-review.js';
+export {
   createCrossrefUniquenessSource,
   createDefaultUniquenessSources,
   createDuckDuckGoUniquenessSource,
@@ -212,6 +220,7 @@ export const defaultBeliefSystem = Object.freeze({
     computed: 1,
     wikidata: 1,
     algorithm: 0.6,
+    literature: 1,
     user: 0.25,
     preference: 1,
     'derived-preference': 0.85,

--- a/js/src/literature-review.js
+++ b/js/src/literature-review.js
@@ -1,0 +1,584 @@
+import { checkText } from './check.js';
+
+const literatureEvidenceSituation = 'literature-screened-paper';
+const bibliographyFields = [
+  'citationKey',
+  'type',
+  'title',
+  'authors',
+  'year',
+  'journal',
+  'doi',
+  'url',
+];
+
+export function reviewClaimAgainstLiterature(input, options = {}) {
+  const fixture = normalizeLiteratureReviewInput(input, options);
+  const evidenceItems = createLiteratureEvidenceItems(fixture);
+  const checked = checkText(fixture.claim.text, {
+    ...options,
+    evidence: evidenceItems,
+    evidenceScoring: {
+      [literatureEvidenceSituation]: 1,
+      ...(options.evidenceScoring ?? {}),
+    },
+    selectedBy: options.selectedBy ?? 'literature-review',
+  });
+
+  return {
+    status: 'reviewed',
+    kind: 'literature-review',
+    claim: fixture.claim,
+    query: fixture.query,
+    screenedAt: fixture.screenedAt,
+    screeningMethod: fixture.screeningMethod,
+    papers: fixture.papers,
+    evidenceItems,
+    checked,
+    summary: summarizeLiteratureReview(fixture, evidenceItems, checked),
+    bibliography: {
+      papers: fixture.papers.map(bibliographyPaper),
+    },
+  };
+}
+
+export function createLiteratureEvidenceItems(input, options = {}) {
+  const fixture = normalizeLiteratureReviewInput(input, options);
+  return fixture.papers
+    .filter((paper) => ['support', 'refute'].includes(paper.decision.polarity))
+    .map((paper, index) => createLiteratureEvidenceItem(fixture, paper, index));
+}
+
+export function exportLiteratureBibliography(input, options = {}) {
+  const format = String(options.format ?? 'bibtex').toLowerCase();
+  if (format === 'bibtex' || format === 'bib') {
+    return exportLiteratureBibTeX(input);
+  }
+  if (format === 'ris') {
+    return exportLiteratureRis(input);
+  }
+  if (format === 'csv') {
+    return exportLiteratureCsv(input);
+  }
+  throw new Error(`Unsupported literature bibliography format: ${format}`);
+}
+
+export function exportLiteratureBibTeX(input) {
+  return `${bibliographyPapersFrom(input)
+    .map((paper) => {
+      const fields = [
+        ['title', paper.title],
+        ['author', bibTeXAuthors(paper.authors)],
+        ['journal', paper.journal],
+        ['year', paper.year],
+        ['volume', paper.volume],
+        ['number', paper.issue],
+        ['pages', paper.pages],
+        ['doi', paper.doi],
+        ['url', paper.url],
+        ['publisher', paper.publisher],
+      ].filter(([, value]) => stringValue(value));
+      const fieldLines = fields.map(
+        ([key, value]) => `  ${key} = {${escapeBibTeX(value)}}`
+      );
+      return `@${bibTeXType(paper.type)}{${paper.citationKey},\n${fieldLines.join(
+        ',\n'
+      )}\n}`;
+    })
+    .join('\n\n')}\n`;
+}
+
+export function exportLiteratureRis(input) {
+  return `${bibliographyPapersFrom(input)
+    .map((paper) => {
+      const lines = [
+        `TY  - ${risType(paper.type)}`,
+        `ID  - ${paper.citationKey}`,
+        `TI  - ${paper.title}`,
+        ...paper.authors.map((author) => `AU  - ${displayAuthor(author)}`),
+        `PY  - ${paper.year}`,
+        risLine('JO', paper.journal),
+        risLine('PB', paper.publisher),
+        risLine('VL', paper.volume),
+        risLine('IS', paper.issue),
+        risLine('SP', firstPage(paper.pages)),
+        risLine('EP', lastPage(paper.pages)),
+        risLine('DO', paper.doi),
+        risLine('UR', paper.url),
+        'ER  -',
+      ].filter(Boolean);
+      return lines.join('\n');
+    })
+    .join('\n\n')}\n`;
+}
+
+export function exportLiteratureCsv(input) {
+  const rows = bibliographyPapersFrom(input).map((paper) =>
+    bibliographyFields
+      .map((field) => csvValue(csvFieldValue(paper, field)))
+      .join(',')
+  );
+  return `${bibliographyFields.join(',')}\n${rows.join('\n')}\n`;
+}
+
+function normalizeLiteratureReviewInput(input, options = {}) {
+  const source = input && typeof input === 'object' ? input : options;
+  const claim = normalizeReviewClaim(source);
+  const rawPapers = normalizeReviewPapers(source);
+
+  return {
+    claim,
+    query: normalizeQuery(source.query),
+    screenedAt: timestampFrom(
+      source.screenedAt ?? options.screenedAt ?? options.now?.() ?? new Date()
+    ),
+    screeningMethod:
+      stringValue(source.screeningMethod) || 'mocked-literature-screening',
+    papers: rawPapers.map((paper, index) => normalizePaper(paper, index)),
+  };
+}
+
+function normalizeReviewClaim(source) {
+  const claimText = stringValue(source.claim?.text ?? source.claim);
+  if (!claimText) {
+    throw new Error('Literature review input is missing claim text.');
+  }
+  return {
+    text: claimText,
+    domain: stringValue(source.claim?.domain) || null,
+  };
+}
+
+function normalizeReviewPapers(source) {
+  const rawPapers = Array.isArray(source.papers) ? source.papers : [];
+  if (rawPapers.length === 0) {
+    throw new Error('Literature review input is missing screened papers.');
+  }
+  return rawPapers;
+}
+
+function normalizeQuery(query) {
+  if (!query || typeof query !== 'object') {
+    return null;
+  }
+  return {
+    text: stringValue(query.text) || null,
+    source: stringValue(query.source) || null,
+    filters:
+      query.filters && typeof query.filters === 'object'
+        ? jsonCompatible(query.filters)
+        : {},
+  };
+}
+
+function normalizePaper(paper, index) {
+  const core = normalizePaperCore(paper, index);
+
+  return {
+    ...core,
+    abstract: stringValue(paper.abstract) || null,
+    decision: normalizeDecision(paper.decision),
+    excerpts: normalizeExcerpts(paper.excerpts),
+  };
+}
+
+function normalizePaperCore(paper, index) {
+  const title = stringValue(paper.title) || `Untitled paper ${index + 1}`;
+  const authors = normalizeAuthors(paper.authors);
+  const year = stringValue(paper.year ?? paper.date).slice(0, 4);
+  const citationKey =
+    stringValue(paper.citationKey) ||
+    createCitationKey({ title, authors, year }, index);
+  return {
+    id: stringValue(paper.id) || citationKey,
+    citationKey,
+    type: stringValue(paper.type) || 'article',
+    title,
+    authors,
+    ...normalizePublicationFields(paper, year),
+  };
+}
+
+function normalizePublicationFields(paper, year) {
+  return {
+    journal: stringValue(paper.journal ?? paper.containerTitle) || null,
+    publisher: stringValue(paper.publisher) || null,
+    year,
+    date: stringValue(paper.date) || year || null,
+    volume: stringValue(paper.volume) || null,
+    issue: stringValue(paper.issue ?? paper.number) || null,
+    pages: stringValue(paper.pages) || null,
+    doi: normalizeDoi(paper.doi),
+    pmid: stringValue(paper.pmid) || null,
+    url: stringValue(paper.url) || doiUrl(paper.doi),
+  };
+}
+
+function normalizeAuthors(value) {
+  const items = Array.isArray(value) ? value : value ? [value] : [];
+  return items
+    .map((author) => {
+      if (typeof author === 'string') {
+        const [family, ...givenParts] = author
+          .split(',')
+          .map((part) => part.trim());
+        return {
+          given: givenParts.join(' ') || null,
+          family: family || author,
+          literal: author,
+        };
+      }
+      return {
+        given: stringValue(author?.given) || null,
+        family: stringValue(author?.family) || null,
+        literal: stringValue(author?.name) || null,
+      };
+    })
+    .filter((author) => author.family || author.literal);
+}
+
+function normalizeDecision(value) {
+  const decision = value && typeof value === 'object' ? value : {};
+  const polarity = normalizePolarity(
+    decision.polarity ?? decision.decision ?? decision.label
+  );
+  return {
+    polarity,
+    weight: normalizeWeight(decision.weight, polarity),
+    label: stringValue(decision.label) || polarity,
+    rationale: stringValue(decision.rationale) || null,
+  };
+}
+
+function normalizePolarity(value) {
+  const normalized = stringValue(value).toLowerCase();
+  if (
+    normalized.includes('refute') ||
+    normalized.includes('contradict') ||
+    normalized.includes('does not support')
+  ) {
+    return 'refute';
+  }
+  if (normalized.includes('support') || normalized.includes('agree')) {
+    return 'support';
+  }
+  return 'uncertain';
+}
+
+function normalizeWeight(value, polarity) {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return Math.max(0, parsed);
+  }
+  return polarity === 'uncertain' ? 0 : 1;
+}
+
+function normalizeExcerpts(value) {
+  const excerpts = Array.isArray(value) ? value : [];
+  return excerpts.map((excerpt, index) => ({
+    id: stringValue(excerpt.id) || `excerpt-${index + 1}`,
+    section: stringValue(excerpt.section) || null,
+    page: stringValue(excerpt.page ?? excerpt.pages) || null,
+    text: stringValue(excerpt.text ?? excerpt.quote),
+  }));
+}
+
+function createLiteratureEvidenceItem(fixture, paper, index) {
+  const sourceUrl = paper.url || doiUrl(paper.doi);
+  const excerptIds = paper.excerpts.map((excerpt) => excerpt.id);
+  return {
+    id: `literature-${safeReference(paper.id || index + 1)}`,
+    key: normalizeClaimKey(fixture.claim.text),
+    polarity: paper.decision.polarity,
+    weight: paper.decision.weight,
+    sourceType: 'literature',
+    situation: literatureEvidenceSituation,
+    sourceUrl,
+    retrievedAt: fixture.screenedAt,
+    claim: literatureEvidenceClaim(fixture.claim.text, paper),
+    identifiers: {
+      paperId: paper.id,
+      citationKey: paper.citationKey,
+      doi: paper.doi ?? '',
+      pmid: paper.pmid ?? '',
+      decision: paper.decision.polarity,
+      excerptIds: excerptIds.join(','),
+    },
+    context: {
+      literature: {
+        claim: fixture.claim,
+        query: fixture.query,
+        paper: bibliographyPaper(paper),
+        excerpts: paper.excerpts,
+        decision: paper.decision,
+        screenedAt: fixture.screenedAt,
+        screeningMethod: fixture.screeningMethod,
+        provenance: {
+          sourceType: 'literature',
+          sourceUrl,
+          retrievedAt: fixture.screenedAt,
+        },
+      },
+      reasoningSteps: literatureReasoningSteps(paper, sourceUrl),
+    },
+  };
+}
+
+function literatureEvidenceClaim(claimText, paper) {
+  const verb = paper.decision.polarity === 'support' ? 'supports' : 'refutes';
+  const rationale = paper.decision.rationale
+    ? ` ${paper.decision.rationale}`
+    : '';
+  return `Paper "${paper.title}" ${verb} the claim "${claimText}".${rationale}`;
+}
+
+function literatureReasoningSteps(paper, sourceUrl) {
+  const steps = [
+    {
+      text: `${paper.title} (${paper.year || 'n.d.'}) screened as ${
+        paper.decision.label
+      }.`,
+      sourceUrl,
+    },
+  ];
+  for (const excerpt of paper.excerpts) {
+    steps.push({
+      text: excerpt.section
+        ? `${excerpt.section}: ${excerpt.text}`
+        : excerpt.text,
+      sourceUrl,
+    });
+  }
+  return steps;
+}
+
+function summarizeLiteratureReview(fixture, evidenceItems, checked) {
+  const supportWeight = roundWeight(
+    evidenceItems
+      .filter((item) => item.polarity === 'support')
+      .reduce((sum, item) => sum + item.weight, 0)
+  );
+  const refuteWeight = roundWeight(
+    evidenceItems
+      .filter((item) => item.polarity === 'refute')
+      .reduce((sum, item) => sum + item.weight, 0)
+  );
+  const totalWeight = supportWeight + refuteWeight;
+  const rawBalance =
+    totalWeight === 0 ? null : (supportWeight - refuteWeight) / totalWeight;
+  const uncertainty =
+    rawBalance === null ? 1 : roundWeight(1 - Math.abs(rawBalance));
+  const statement = checked.statements[0] ?? null;
+
+  return {
+    totalPapers: fixture.papers.length,
+    screenedPapers: fixture.papers.length,
+    supportingPapers: fixture.papers.filter(
+      (paper) => paper.decision.polarity === 'support'
+    ).length,
+    refutingPapers: fixture.papers.filter(
+      (paper) => paper.decision.polarity === 'refute'
+    ).length,
+    uncertainPapers: fixture.papers.filter(
+      (paper) => paper.decision.polarity === 'uncertain'
+    ).length,
+    evidenceLinks: evidenceItems.length,
+    confidence: statement?.correctness ?? null,
+    agreement: {
+      label: agreementLabel(supportWeight, refuteWeight),
+      supportWeight,
+      refuteWeight,
+      rawBalance: rawBalance === null ? null : roundWeight(rawBalance),
+      uncertainty,
+    },
+  };
+}
+
+function agreementLabel(supportWeight, refuteWeight) {
+  if (supportWeight > 0 && refuteWeight > 0) {
+    return supportWeight >= refuteWeight ? 'mixed-support' : 'mixed-refute';
+  }
+  if (supportWeight > 0) {
+    return 'supports';
+  }
+  if (refuteWeight > 0) {
+    return 'refutes';
+  }
+  return 'uncertain';
+}
+
+function bibliographyPapersFrom(input) {
+  if (Array.isArray(input)) {
+    return input.map((paper, index) => normalizePaper(paper, index));
+  }
+  if (input?.bibliography?.papers) {
+    return input.bibliography.papers.map((paper, index) =>
+      normalizePaper(paper, index)
+    );
+  }
+  if (Array.isArray(input?.papers)) {
+    return input.papers.map((paper, index) => normalizePaper(paper, index));
+  }
+  throw new Error('Literature bibliography export requires papers.');
+}
+
+function bibliographyPaper(paper) {
+  return {
+    id: paper.id,
+    citationKey: paper.citationKey,
+    type: paper.type,
+    title: paper.title,
+    authors: paper.authors,
+    journal: paper.journal,
+    publisher: paper.publisher,
+    year: paper.year,
+    date: paper.date,
+    volume: paper.volume,
+    issue: paper.issue,
+    pages: paper.pages,
+    doi: paper.doi,
+    pmid: paper.pmid,
+    url: paper.url,
+  };
+}
+
+function bibTeXType(type) {
+  const normalized = String(type ?? '').toLowerCase();
+  if (normalized.includes('book')) {
+    return 'book';
+  }
+  if (normalized.includes('proceeding') || normalized.includes('conference')) {
+    return 'inproceedings';
+  }
+  if (normalized.includes('article')) {
+    return 'article';
+  }
+  return 'misc';
+}
+
+function risType(type) {
+  const normalized = String(type ?? '').toLowerCase();
+  if (normalized.includes('book')) {
+    return 'BOOK';
+  }
+  if (normalized.includes('proceeding') || normalized.includes('conference')) {
+    return 'CONF';
+  }
+  if (normalized.includes('article')) {
+    return 'JOUR';
+  }
+  return 'GEN';
+}
+
+function bibTeXAuthors(authors) {
+  return authors.map(displayAuthor).join(' and ');
+}
+
+function displayAuthor(author) {
+  if (author.literal && !author.family) {
+    return author.literal;
+  }
+  if (author.given) {
+    return `${author.family}, ${author.given}`;
+  }
+  return author.family ?? author.literal ?? '';
+}
+
+function risLine(tag, value) {
+  const text = stringValue(value);
+  return text ? `${tag}  - ${text}` : '';
+}
+
+function firstPage(pages) {
+  return splitPages(pages)[0] ?? '';
+}
+
+function lastPage(pages) {
+  return splitPages(pages)[1] ?? '';
+}
+
+function splitPages(pages) {
+  const text = stringValue(pages);
+  return text ? text.split(/\s*[-–]\s*/u) : [];
+}
+
+function csvFieldValue(paper, field) {
+  if (field === 'authors') {
+    return paper.authors.map(displayAuthor).join('; ');
+  }
+  return paper[field] ?? '';
+}
+
+function csvValue(value) {
+  return `"${String(value ?? '').replace(/"/g, '""')}"`;
+}
+
+function createCitationKey(paper, index) {
+  const firstAuthor = paper.authors[0]?.family ?? 'source';
+  const year = paper.year || 'nd';
+  const titleWord = paper.title.split(/\s+/u).find(Boolean) ?? 'paper';
+  return (
+    safeReference(`${firstAuthor}${year}${titleWord}`) || `paper${index + 1}`
+  );
+}
+
+function normalizeDoi(value) {
+  return stringValue(value).replace(/^https?:\/\/doi\.org\//iu, '') || null;
+}
+
+function doiUrl(value) {
+  const doi = normalizeDoi(value);
+  return doi ? `https://doi.org/${doi}` : null;
+}
+
+function normalizeClaimKey(value) {
+  return String(value ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
+    .trim();
+}
+
+function timestampFrom(value) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const raw = String(value ?? '').trim();
+  if (!raw) {
+    return new Date().toISOString();
+  }
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? raw : parsed.toISOString();
+}
+
+function stringValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value).trim();
+  }
+  return '';
+}
+
+function escapeBibTeX(value) {
+  return String(value ?? '').replace(/[{}]/gu, '');
+}
+
+function safeReference(value) {
+  return (
+    String(value)
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'value'
+  );
+}
+
+function roundWeight(value) {
+  return Number(Number(value).toFixed(6));
+}
+
+function jsonCompatible(value) {
+  return JSON.parse(JSON.stringify(value));
+}

--- a/js/src/preferences.js
+++ b/js/src/preferences.js
@@ -146,6 +146,12 @@ export const preferenceEvidenceSituationDefinitions = Object.freeze([
     group: 'knowledge-source',
     defaultProbability: 0.87,
   }),
+  Object.freeze({
+    id: 'literature-screened-paper',
+    label: 'Screened literature paper',
+    group: 'knowledge-source',
+    defaultProbability: 1,
+  }),
 ]);
 
 const defaultPreferenceProfile = Object.freeze({

--- a/js/tests/fixtures/issue-91-literature-review.json
+++ b/js/tests/fixtures/issue-91-literature-review.json
@@ -1,0 +1,102 @@
+{
+  "claim": {
+    "text": "Daily reflective journaling improves writing self-efficacy in first-year students",
+    "domain": "writing pedagogy"
+  },
+  "query": {
+    "text": "\"reflective journaling\" \"writing self-efficacy\" first-year students",
+    "source": "mocked-literature-search",
+    "filters": {
+      "publicationYears": "2019-2025",
+      "studyTypes": ["randomized pilot", "quasi-experimental", "mixed-methods"]
+    }
+  },
+  "screenedAt": "2026-05-26T00:00:00.000Z",
+  "screeningMethod": "mocked-human-screening-fixture",
+  "papers": [
+    {
+      "id": "lee-2022-reflective-journaling",
+      "citationKey": "lee2022journaling",
+      "type": "article",
+      "title": "Structured reflection journals and writing confidence in first-year seminars",
+      "authors": [
+        { "given": "Mina", "family": "Lee" },
+        { "given": "Owen", "family": "Patel" }
+      ],
+      "journal": "Journal of Writing Pedagogy Fixtures",
+      "year": 2022,
+      "doi": "10.5555/jwpf.2022.001",
+      "url": "https://example.test/papers/lee-2022-reflective-journaling",
+      "decision": {
+        "polarity": "support",
+        "weight": 0.8,
+        "label": "supports",
+        "rationale": "The intervention group reported higher post-course self-efficacy than the comparison group."
+      },
+      "excerpts": [
+        {
+          "id": "lee-2022-results",
+          "section": "Results",
+          "page": "14",
+          "text": "Mean writing self-efficacy increased more for students assigned to weekly guided reflection journals."
+        }
+      ]
+    },
+    {
+      "id": "nguyen-2023-optional-journaling",
+      "citationKey": "nguyen2023optional",
+      "type": "article",
+      "title": "Optional journaling and writing confidence in introductory composition",
+      "authors": [
+        { "given": "Tara", "family": "Nguyen" },
+        { "given": "Luis", "family": "Romero" }
+      ],
+      "journal": "Composition Studies Fixture Review",
+      "year": 2023,
+      "doi": "10.5555/csfr.2023.017",
+      "url": "https://example.test/papers/nguyen-2023-optional-journaling",
+      "decision": {
+        "polarity": "refute",
+        "weight": 0.5,
+        "label": "does not support",
+        "rationale": "The optional journaling condition did not differ from the no-journal comparison on the self-efficacy scale."
+      },
+      "excerpts": [
+        {
+          "id": "nguyen-2023-discussion",
+          "section": "Discussion",
+          "page": "22",
+          "text": "Optional journal completion was not associated with a statistically reliable self-efficacy gain."
+        }
+      ]
+    },
+    {
+      "id": "smith-2024-guided-reflection",
+      "citationKey": "smith2024guided",
+      "type": "article",
+      "title": "Guided reflective writing as a confidence scaffold for novice academic writers",
+      "authors": [
+        { "given": "Ari", "family": "Smith" },
+        { "given": "Nadia", "family": "Khan" }
+      ],
+      "journal": "Teaching Writing Fixture Quarterly",
+      "year": 2024,
+      "doi": "10.5555/twfq.2024.004",
+      "url": "https://example.test/papers/smith-2024-guided-reflection",
+      "decision": {
+        "polarity": "support",
+        "weight": 0.7,
+        "label": "supports with caveats",
+        "rationale": "The guided reflection arm improved confidence, but only when instructors supplied weekly prompts."
+      },
+      "excerpts": [
+        {
+          "id": "smith-2024-results",
+          "section": "Results",
+          "page": "9",
+          "text": "Prompted reflection produced a moderate gain in academic writing self-efficacy by the final week."
+        }
+      ]
+    }
+  ]
+}

--- a/js/tests/integration/issue-91-literature-review.test.js
+++ b/js/tests/integration/issue-91-literature-review.test.js
@@ -1,0 +1,103 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'test-anywhere';
+import {
+  exportLiteratureBibliography,
+  exportLiteratureBibTeX,
+  exportLiteratureCsv,
+  exportLiteratureRis,
+  reviewClaimAgainstLiterature,
+} from '../../src/index.js';
+import { runCliAsync } from '../../src/cli.js';
+
+const FIXTURE_PATH = 'js/tests/fixtures/issue-91-literature-review.json';
+
+async function loadFixture() {
+  return JSON.parse(await readFile(FIXTURE_PATH, 'utf8'));
+}
+
+describe('issue 91 - literature-review evidence workflows', () => {
+  it('checks one claim against multiple screened papers without using LLM truth evidence', async () => {
+    const fixture = await loadFixture();
+    const review = reviewClaimAgainstLiterature(fixture, {
+      realWorldUncertainty: 0,
+    });
+
+    expect(review.status).toBe('reviewed');
+    expect(review.kind).toBe('literature-review');
+    expect(review.claim.text).toBe(fixture.claim.text);
+    expect(review.papers.length).toBe(3);
+    expect(review.evidenceItems.length).toBe(3);
+    expect(review.evidenceItems.every((item) => item.sourceType)).toBe(true);
+    expect(review.evidenceItems.some((item) => item.sourceType === 'llm')).toBe(
+      false
+    );
+    expect(review.summary.supportingPapers).toBe(2);
+    expect(review.summary.refutingPapers).toBe(1);
+    expect(review.summary.agreement.label).toBe('mixed-support');
+    expect(review.summary.agreement.supportWeight).toBe(1.5);
+    expect(review.summary.agreement.refuteWeight).toBe(0.5);
+    expect(review.summary.agreement.uncertainty).toBeGreaterThan(0);
+    expect(review.checked.statements[0].correctness).toBe(0.75);
+
+    const evidenceLink =
+      review.checked.statements[0].analysis.linksNetwork.links
+        .filter((link) => link.role === 'evidence')
+        .find(
+          (link) => link.value.identifiers.paperId === fixture.papers[0].id
+        );
+    expect(evidenceLink.provenance.sourceType).toBe('literature');
+    expect(evidenceLink.provenance.sourceUrl).toBe(fixture.papers[0].url);
+    expect(evidenceLink.value.context.literature.paper.title).toBe(
+      fixture.papers[0].title
+    );
+    expect(evidenceLink.value.context.literature.excerpts[0].text).toContain(
+      'writing self-efficacy'
+    );
+    expect(evidenceLink.value.context.literature.decision.rationale).toContain(
+      'intervention group'
+    );
+  });
+
+  it('exports literature-backed evidence bibliography data as BibTeX, RIS, and CSV', async () => {
+    const fixture = await loadFixture();
+    const review = reviewClaimAgainstLiterature(fixture);
+    const bibtex = exportLiteratureBibTeX(review);
+    const ris = exportLiteratureRis(review);
+    const csv = exportLiteratureCsv(review);
+
+    expect(exportLiteratureBibliography(review, { format: 'bibtex' })).toBe(
+      bibtex
+    );
+    expect(bibtex).toContain('@article{lee2022journaling,');
+    expect(bibtex).toContain('doi = {10.5555/jwpf.2022.001}');
+    expect(ris).toContain('TY  - JOUR');
+    expect(ris).toContain('DO  - 10.5555/csfr.2023.017');
+    expect(csv).toContain(
+      'citationKey,type,title,authors,year,journal,doi,url'
+    );
+    expect(csv).toContain('"lee2022journaling"');
+    expect(csv).toContain('"Lee, Mina; Patel, Owen"');
+  });
+
+  it('supports the literature-review fixture workflow from the CLI', async () => {
+    const output = {
+      logs: [],
+      errors: [],
+      log(value) {
+        this.logs.push(value);
+      },
+      error(value) {
+        this.errors.push(value);
+      },
+    };
+    const exitCode = await runCliAsync(
+      ['literature-review', '--fixture', FIXTURE_PATH, '--format', 'ris'],
+      output
+    );
+
+    expect(exitCode).toBe(0);
+    expect(output.errors).toEqual([]);
+    expect(output.logs[0]).toContain('TY  - JOUR');
+    expect(output.logs[0]).toContain('DO  - 10.5555/twfq.2024.004');
+  });
+});


### PR DESCRIPTION
## What

- Adds a literature-review adapter that turns screened paper metadata, excerpts, and support/refute decisions into normal `literature` evidence items and evidence links with provenance.
- Adds BibTeX, RIS, and CSV bibliography exports for literature-backed evidence.
- Adds a `literature-review` CLI fixture workflow plus a mocked three-paper fixture that reports mixed agreement and uncertainty without using LLM output as truth evidence.

## Why

Fixes #91.

## How To Reproduce

```bash
node js/src/cli.js literature-review --fixture js/tests/fixtures/issue-91-literature-review.json --format markdown
node js/src/cli.js literature-review --fixture js/tests/fixtures/issue-91-literature-review.json --format bibtex
```

## Testing

```bash
node --test js/tests/integration/issue-91-literature-review.test.js
node --test js/tests/integration/issue-87-claim-review.test.js
node --test js/tests/integration/issue-88-provenance-jsonld.test.js
node --test js/tests/integration/issue-90-originality-report.test.js
npm test
npm run check
```
