### PR TITLE
feat: add scoped graph evidence exports

### DIFF
--- a/.changeset/issue-92-graph-interchange.md
+++ b/.changeset/issue-92-graph-interchange.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': minor
+---
+
+Add scoped SPARQL, RDF-triple, and property-graph evidence exports that preserve bounded real-world confidence guardrails.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
 # Updated: 2026-05-26T06:39:16.671Z
+# Updated: 2026-05-26T06:58:24.996Z

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Core exports:
 - `exportEvidenceJsonLd(result)` and `exportEvidenceProvJsonLd(result)` export
   `/analyze` and `/check` evidence provenance as JSON-LD and a PROV-O-compatible
   JSON-LD graph while preserving Links Notation output.
+- `exportScopedSparqlEvidence(result)`, `exportEvidenceRdfTriples(result)`,
+  and `exportEvidencePropertyGraph(result)` project existing Q/P evidence links
+  into scoped SPARQL, RDF-triple, and property-graph interchange shapes without
+  changing the bounded real-world confidence calculation.
 - `reviewClaimAgainstLiterature(fixture)` checks a claim against screened paper
   metadata/excerpts as normal evidence links, reports literature agreement and
   uncertainty, and `exportLiteratureBibliography(result, { format })` emits
@@ -108,6 +112,7 @@ Real-world confidence is intentionally bounded away from absolute `0%` and
 node js/src/cli.js analyze "1 + 1 = 2"
 node js/src/cli.js analyze --input "Earth orbits the Sun" --format links
 node js/src/cli.js analyze --input "Earth orbits the Sun" --format json-ld
+node js/src/cli.js analyze --input "Earth orbits the Sun" --format sparql --limit 5
 node js/src/cli.js analyze --input "Paris is the capital of France" --live
 node js/src/cli.js formalize --input "Hawaii is a state." --format markdown
 node js/src/cli.js translate --input "Hawaii is a state." --to ru --format markdown
@@ -137,6 +142,7 @@ Routes:
 
 - `GET /health`
 - `GET /analyze?input=...&format=json|links|json-ld|prov-o&select=0`
+- `GET /analyze?input=...&format=sparql|rdf|property-graph&limit=50`
 - `GET /analyze?input=...&live=true`
 - `POST /analyze` with `{ "input": "...", "format": "json" }`
 - `GET /formalize?input=...&format=json|links|markdown|html`

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -6,9 +6,12 @@ import { makeConfig } from 'lino-arguments';
 import {
   analyzeStatement,
   analyzeStatementWithLiveEvidence,
+  exportEvidencePropertyGraph,
   exportEvidenceJsonLd,
   exportEvidenceProvJsonLd,
+  exportEvidenceRdfTriples,
   exportLiteratureBibliography,
+  exportScopedSparqlEvidence,
   naturalizeExpressionWith,
   parsePreferenceProfile,
   reviewClaimAgainstLiterature,
@@ -86,6 +89,9 @@ export function parseCliArguments(args) {
     },
     '--match-threshold': () => {
       options.matchThreshold = Number(nextValue());
+    },
+    '--limit': () => {
+      options.limit = Number(nextValue());
     },
     '--max-ngram': () => {
       options.maxNgramSize = Number(nextValue(3));
@@ -248,6 +254,10 @@ function configureCliYargs({ yargs, getenv }) {
       type: 'number',
       default: getenv('MATCH_THRESHOLD', Number.NaN),
     })
+    .option('limit', {
+      type: 'number',
+      default: getenv('LIMIT', Number.NaN),
+    })
     .option('max-ngram', {
       type: 'number',
       default: getenv('MAX_NGRAM', Number.NaN),
@@ -329,6 +339,7 @@ function createCliOptions(config) {
   assignStringOption(options, 'skipListPath', config.skipList);
   assignStringOption(options, 'translationFixesPath', config.fixes);
   assignNumberOption(options, 'matchThreshold', config.matchThreshold);
+  assignNumberOption(options, 'limit', config.limit);
   assignNumberOption(options, 'maxNgramSize', config.maxNgram);
   assignStringOption(
     options,
@@ -822,6 +833,32 @@ function cliAnalysisOptions(options) {
 }
 
 function emitCliAnalysis(options, output, analysis) {
+  if (isSparqlFormat(options.format)) {
+    output.log(
+      exportScopedSparqlEvidence(analysis, { limit: options.limit }).query
+    );
+    return 0;
+  }
+  if (isPropertyGraphFormat(options.format)) {
+    output.log(
+      JSON.stringify(
+        exportEvidencePropertyGraph(analysis, { limit: options.limit }),
+        null,
+        2
+      )
+    );
+    return 0;
+  }
+  if (isRdfFormat(options.format)) {
+    output.log(
+      JSON.stringify(
+        exportEvidenceRdfTriples(analysis, { limit: options.limit }),
+        null,
+        2
+      )
+    );
+    return 0;
+  }
   if (isProvOFormat(options.format)) {
     output.log(JSON.stringify(exportEvidenceProvJsonLd(analysis), null, 2));
     return 0;
@@ -840,6 +877,32 @@ function emitCliAnalysis(options, output, analysis) {
 }
 
 function emitCheckResult(options, output, result) {
+  if (isSparqlFormat(options.format)) {
+    output.log(
+      exportScopedSparqlEvidence(result, { limit: options.limit }).query
+    );
+    return 0;
+  }
+  if (isPropertyGraphFormat(options.format)) {
+    output.log(
+      JSON.stringify(
+        exportEvidencePropertyGraph(result, { limit: options.limit }),
+        null,
+        2
+      )
+    );
+    return 0;
+  }
+  if (isRdfFormat(options.format)) {
+    output.log(
+      JSON.stringify(
+        exportEvidenceRdfTriples(result, { limit: options.limit }),
+        null,
+        2
+      )
+    );
+    return 0;
+  }
   if (isClaimReviewFormat(options.format)) {
     output.log(
       JSON.stringify(
@@ -934,6 +997,18 @@ function isClaimReviewFormat(format) {
   return format === 'claim-review' || format === 'claimreview';
 }
 
+function isSparqlFormat(format) {
+  return format === 'sparql' || format === 'sparql-query';
+}
+
+function isPropertyGraphFormat(format) {
+  return format === 'property-graph' || format === 'graph';
+}
+
+function isRdfFormat(format) {
+  return format === 'rdf' || format === 'rdf-triples';
+}
+
 function isJsonLdFormat(format) {
   return (
     format === 'json-ld' ||
@@ -1004,7 +1079,7 @@ Commands:
 
 Options:
   -i, --input <text>             Statement text
-  -f, --format <json|links|markdown|html|claim-review|json-ld|prov-o>
+  -f, --format <json|links|markdown|html|claim-review|json-ld|prov-o|sparql|rdf|property-graph>
   -s, --select <index>           Interpretation index (analyze), default 0
   --live                         analyze: resolve through Wikimedia APIs
   --target <wikipedia|wikidata|local>
@@ -1025,6 +1100,7 @@ Options:
   --skip-list <file.json>        translation-quality: known Wikipedia translation deltas
   --fixes <file.json>            translation-quality: curated translation fixes
   --match-threshold <0..1>       translation-quality: token coverage threshold
+  --limit <n>                    graph/SPARQL export record limit (default 50)
   --score <situation=probability>
                                  check/fact-check: override evidence scoring
   --source, --source-url <url>    check/fact-check: source URL for ClaimReview

--- a/js/src/graph-interchange.js
+++ b/js/src/graph-interchange.js
@@ -1,0 +1,772 @@
+import { serializeLinksNotation } from './reporting.js';
+
+const metaNamespace = 'https://link-assistant.github.io/meta-expression/vocab#';
+const provNamespace = 'http://www.w3.org/ns/prov#';
+const rdfNamespace = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+const xsdNamespace = 'http://www.w3.org/2001/XMLSchema#';
+const wikidataEntityPrefix = 'http://www.wikidata.org/entity/';
+const wikidataDirectPrefix = 'http://www.wikidata.org/prop/direct/';
+const defaultLimit = 50;
+const maxLimit = 500;
+
+export function exportScopedSparqlEvidence(input, options = {}) {
+  const model = createGraphEvidenceModel(input, options);
+  const scopedRecords = model.allEvidenceRecords
+    .map(sparqlScopeRecord)
+    .filter(Boolean);
+  const selected = scopedRecords.slice(0, model.limit);
+
+  return {
+    format: 'meta-expression-scoped-sparql',
+    sourceSurface: model.sourceSurface,
+    exportedAt: model.exportedAt,
+    limits: {
+      maxEvidenceRecords: model.limit,
+      selectedEvidenceRecords: selected.length,
+      availableEvidenceRecords: scopedRecords.length,
+      truncated: scopedRecords.length > selected.length,
+    },
+    provenance: createExportProvenance(model),
+    guardrails: model.guardrails,
+    scope: createSparqlScope(selected),
+    prefixes: sparqlPrefixes(),
+    query: createScopedSparqlQuery(selected, model),
+  };
+}
+
+export function exportEvidenceRdfTriples(input, options = {}) {
+  const model = createGraphEvidenceModel(input, options);
+  const triples = [];
+
+  for (const analysis of model.analyses) {
+    triples.push(
+      iriTriple(analysis.id, 'rdf:type', 'meta:Analysis'),
+      literalTriple(
+        analysis.id,
+        'meta:statementText',
+        analysis.statementText,
+        'xsd:string'
+      )
+    );
+    addGuardrailTriples(triples, analysis.id, analysis.guardrails);
+  }
+
+  for (const record of model.evidenceRecords) {
+    triples.push(...evidenceRecordTriples(record));
+  }
+
+  return {
+    format: 'meta-expression-rdf-triples',
+    sourceSurface: model.sourceSurface,
+    exportedAt: model.exportedAt,
+    limits: model.limits,
+    provenance: createExportProvenance(model),
+    guardrails: model.guardrails,
+    mappings: model.mappings,
+    triples,
+  };
+}
+
+export function importEvidenceRdfTriples(input) {
+  const triples = Array.isArray(input?.triples) ? input.triples : [];
+  const records = new Map();
+
+  for (const triple of triples) {
+    if (triple.predicate === 'rdf:type') {
+      continue;
+    }
+    const record = records.get(triple.subject) ?? {
+      rdfSubject: triple.subject,
+      identifiers: {},
+    };
+    applyRdfTriple(record, triple);
+    records.set(triple.subject, record);
+  }
+
+  return {
+    status: 'imported',
+    format: 'meta-expression-rdf-triples',
+    evidenceRecords: [...records.values()].filter((record) => record.claim),
+    guardrails: input?.guardrails ?? null,
+    mappings: input?.mappings ?? [],
+  };
+}
+
+export function exportEvidencePropertyGraph(input, options = {}) {
+  const model = createGraphEvidenceModel(input, options);
+  const graph = {
+    format: 'meta-expression-property-graph',
+    sourceSurface: model.sourceSurface,
+    exportedAt: model.exportedAt,
+    limits: model.limits,
+    provenance: createExportProvenance(model),
+    guardrails: model.guardrails,
+    mappings: model.mappings,
+    nodes: [],
+    relationships: [],
+  };
+  const nodes = new Map();
+
+  for (const analysis of model.analyses) {
+    addNode(nodes, {
+      id: analysis.id,
+      labels: ['Analysis'],
+      properties: {
+        statement: analysis.statementText,
+        sourceSurface: model.sourceSurface,
+        confidence: analysis.guardrails.boundedConfidence,
+        correctness: analysis.guardrails.correctness,
+        signedConfidence: analysis.guardrails.signedConfidence,
+        rawConfidence: analysis.guardrails.rawConfidence,
+        bounded: analysis.guardrails.bounded,
+      },
+    });
+  }
+
+  for (const record of model.evidenceRecords) {
+    addEvidenceGraphRecord(graph, nodes, record);
+  }
+
+  graph.nodes = [...nodes.values()];
+  return graph;
+}
+
+export function importEvidencePropertyGraph(input) {
+  const nodes = Array.isArray(input?.nodes) ? input.nodes : [];
+  const relationships = Array.isArray(input?.relationships)
+    ? input.relationships
+    : [];
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const evidenceNodes = nodes.filter((node) =>
+    node.labels?.includes('Evidence')
+  );
+  const evidenceRecords = evidenceNodes.map((node) =>
+    importEvidenceNode(node, relationships, nodeById)
+  );
+
+  return {
+    status: 'imported',
+    format: 'meta-expression-property-graph',
+    evidenceRecords,
+    guardrails: input?.guardrails ?? null,
+    mappings: input?.mappings ?? [],
+  };
+}
+
+function createGraphEvidenceModel(input, options) {
+  const sourceSurface = input?.status === 'checked' ? 'check' : 'analyze';
+  validateGraphInput(input, sourceSurface);
+
+  const limit = normalizeLimit(options.limit);
+  const baseId = normalizeBaseId(
+    options.baseId ??
+      `urn:meta-expression:${sourceSurface}:${surfaceKey(input)}`
+  );
+  const model = {
+    baseId,
+    sourceSurface,
+    exportedAt: timestampFrom(
+      options.exportedAt ?? options.now?.() ?? new Date()
+    ),
+    limit,
+    linksNotation: linksNotationFor(input, sourceSurface),
+    analyses: [],
+    evidenceRecords: [],
+    mappings: [],
+    guardrails: null,
+    allEvidenceRecords: [],
+    limits: {
+      maxEvidenceRecords: limit,
+      exportedEvidenceRecords: 0,
+      availableEvidenceRecords: 0,
+      truncated: false,
+    },
+  };
+
+  const analyses = sourceSurface === 'check' ? input.statements : [input];
+  for (const [index, value] of analyses.entries()) {
+    const analysis = sourceSurface === 'check' ? value.analysis : value;
+    model.analyses.push(createGraphAnalysis(analysis, model, index, value));
+  }
+
+  model.allEvidenceRecords = model.evidenceRecords;
+  model.evidenceRecords = model.evidenceRecords.slice(0, limit);
+  model.mappings = model.evidenceRecords.map((record) => ({
+    linksNotationLinkId: record.linksNotationLinkId,
+    rdfSubject: record.id,
+    propertyGraphNodeId: record.id,
+  }));
+  model.guardrails = combinedGuardrails(model.analyses);
+  model.limits.exportedEvidenceRecords = model.evidenceRecords.length;
+  model.limits.truncated =
+    model.limits.availableEvidenceRecords > model.evidenceRecords.length;
+  return model;
+}
+
+function createGraphAnalysis(analysis, model, index, source) {
+  const ordinal = index + 1;
+  const id = nodeId(model.baseId, `analysis-${ordinal}`);
+  const entry = {
+    id,
+    statementText:
+      stringValue(source.text) || stringValue(analysis.statement?.value?.text),
+    guardrails: guardrailsForResult(analysis.result),
+  };
+  const evidenceLinks = evidenceLinksFor(analysis);
+
+  model.limits.availableEvidenceRecords += evidenceLinks.length;
+  for (const [evidenceIndex, link] of evidenceLinks.entries()) {
+    model.evidenceRecords.push(
+      createGraphEvidenceRecord(link, entry, model, evidenceIndex)
+    );
+  }
+  return entry;
+}
+
+function evidenceLinksFor(analysis) {
+  const links = analysis.linksNetwork?.links ?? [];
+  const evidenceLinks = links.filter((link) => link.role === 'evidence');
+  if (evidenceLinks.length > 0) {
+    return evidenceLinks;
+  }
+  return [
+    ...(analysis.result?.supportingEvidence ?? []),
+    ...(analysis.result?.refutingEvidence ?? []),
+  ].map((value, index) => ({
+    id: value.id ?? `evidence-${index + 1}`,
+    value,
+    provenance: {
+      sourceType: value.sourceType,
+      sourceUrl: value.sourceUrl,
+      retrievedAt: value.retrievedAt,
+    },
+  }));
+}
+
+function createGraphEvidenceRecord(link, analysis, model, index) {
+  const evidence = link.value ?? {};
+  const id = nodeId(
+    model.baseId,
+    `${safeReference(analysis.id)}-evidence-${safeReference(link.id ?? index + 1)}`
+  );
+  return {
+    id,
+    analysisId: analysis.id,
+    linksNotationLinkId: link.id,
+    claim: stringValue(evidence.claim),
+    polarity: stringValue(evidence.polarity) || 'support',
+    weight: finiteNumber(evidence.weight) ?? 0,
+    sourceType: stringValue(evidence.sourceType) || 'unknown',
+    sourceUrl: stringValue(evidence.sourceUrl) || null,
+    retrievedAt: stringValue(evidence.retrievedAt) || null,
+    situation: situationId(evidence.situation),
+    identifiers: jsonCompatible(evidence.identifiers ?? {}),
+    provenance: jsonCompatible(link.provenance ?? {}),
+    guardrails: analysis.guardrails,
+  };
+}
+
+function evidenceRecordTriples(record) {
+  const triples = [
+    iriTriple(record.id, 'rdf:type', 'meta:EvidenceRecord', record),
+    literalTriple(
+      record.id,
+      'meta:linksNotationLinkId',
+      record.linksNotationLinkId
+    ),
+    literalTriple(record.id, 'meta:claim', record.claim),
+    literalTriple(record.id, 'meta:polarity', record.polarity),
+    literalTriple(record.id, 'meta:weight', record.weight, 'xsd:decimal'),
+    literalTriple(record.id, 'meta:sourceType', record.sourceType),
+    literalTriple(record.id, 'meta:situation', record.situation),
+  ];
+  if (record.sourceUrl) {
+    triples.push(iriTriple(record.id, 'prov:wasDerivedFrom', record.sourceUrl));
+  }
+  if (record.retrievedAt) {
+    triples.push(
+      literalTriple(record.id, 'prov:generatedAtTime', record.retrievedAt)
+    );
+  }
+  addIdentifierTriples(triples, record);
+  return triples;
+}
+
+function addIdentifierTriples(triples, record) {
+  const subject = wikidataId(record.identifiers.subject, 'Q');
+  const property = wikidataId(record.identifiers.property, 'P');
+  const object = wikidataId(record.identifiers.object, 'Q');
+  if (subject) {
+    triples.push(iriTriple(record.id, 'meta:wikidataSubject', `wd:${subject}`));
+  }
+  if (property) {
+    triples.push(
+      iriTriple(record.id, 'meta:wikidataProperty', `wdt:${property}`)
+    );
+  }
+  if (object) {
+    triples.push(iriTriple(record.id, 'meta:wikidataObject', `wd:${object}`));
+  }
+}
+
+function addGuardrailTriples(triples, subject, guardrails) {
+  triples.push(
+    literalTriple(
+      subject,
+      'meta:boundedConfidence',
+      guardrails.boundedConfidence,
+      'xsd:decimal'
+    ),
+    literalTriple(
+      subject,
+      'meta:rawConfidence',
+      guardrails.rawConfidence,
+      'xsd:decimal'
+    ),
+    literalTriple(subject, 'meta:confidenceBounded', guardrails.bounded)
+  );
+}
+
+function applyRdfTriple(record, triple) {
+  const value = triple.object?.value;
+  if (triple.predicate === 'meta:linksNotationLinkId') {
+    record.linksNotationLinkId = value;
+  } else if (triple.predicate === 'meta:claim') {
+    record.claim = value;
+  } else if (triple.predicate === 'meta:polarity') {
+    record.polarity = value;
+  } else if (triple.predicate === 'meta:weight') {
+    record.weight = Number(value);
+  } else if (triple.predicate === 'meta:sourceType') {
+    record.sourceType = value;
+  } else if (triple.predicate === 'meta:situation') {
+    record.situation = value;
+  } else if (triple.predicate === 'prov:wasDerivedFrom') {
+    record.sourceUrl = value;
+  } else if (triple.predicate === 'prov:generatedAtTime') {
+    record.retrievedAt = value;
+  } else if (triple.predicate === 'meta:wikidataSubject') {
+    record.identifiers.subject = compactWikidataId(value);
+  } else if (triple.predicate === 'meta:wikidataProperty') {
+    record.identifiers.property = compactWikidataId(value);
+  } else if (triple.predicate === 'meta:wikidataObject') {
+    record.identifiers.object = compactWikidataId(value);
+  }
+}
+
+function addEvidenceGraphRecord(graph, nodes, record) {
+  addNode(nodes, {
+    id: record.id,
+    labels: ['Evidence'],
+    properties: {
+      linksNotationLinkId: record.linksNotationLinkId,
+      claim: record.claim,
+      polarity: record.polarity,
+      weight: record.weight,
+      sourceType: record.sourceType,
+      sourceUrl: record.sourceUrl,
+      retrievedAt: record.retrievedAt,
+      situation: record.situation,
+    },
+  });
+  addRelationship(graph, record.analysisId, record.id, 'HAS_EVIDENCE', {
+    polarity: record.polarity,
+    weight: record.weight,
+  });
+  addSourceNode(graph, nodes, record);
+  addWikidataNodes(graph, nodes, record);
+}
+
+function addSourceNode(graph, nodes, record) {
+  if (!record.sourceUrl) {
+    return;
+  }
+  const id = nodeId(
+    graph.provenance.baseId,
+    `source-${shortHash(record.sourceUrl)}`
+  );
+  addNode(nodes, {
+    id,
+    labels: ['EvidenceSource'],
+    properties: {
+      sourceType: record.sourceType,
+      url: record.sourceUrl,
+      retrievedAt: record.retrievedAt,
+    },
+  });
+  addRelationship(graph, record.id, id, 'DERIVED_FROM', {});
+}
+
+function addWikidataNodes(graph, nodes, record) {
+  const entries = [
+    ['HAS_WIKIDATA_SUBJECT', 'WikidataEntity', 'subject', 'Q'],
+    ['HAS_WIKIDATA_PROPERTY', 'WikidataProperty', 'property', 'P'],
+    ['HAS_WIKIDATA_OBJECT', 'WikidataEntity', 'object', 'Q'],
+  ];
+  for (const [type, label, key, prefix] of entries) {
+    const wikidata = wikidataId(record.identifiers[key], prefix);
+    if (!wikidata) {
+      continue;
+    }
+    const id = nodeId(graph.provenance.baseId, `wikidata-${wikidata}`);
+    addNode(nodes, {
+      id,
+      labels: [label],
+      properties: {
+        wikidataId: wikidata,
+        iri: wikidataIri(wikidata),
+      },
+    });
+    addRelationship(graph, record.id, id, type, {});
+  }
+}
+
+function importEvidenceNode(node, relationships, nodeById) {
+  const record = {
+    linksNotationLinkId: node.properties.linksNotationLinkId,
+    claim: node.properties.claim,
+    polarity: node.properties.polarity,
+    weight: node.properties.weight,
+    sourceType: node.properties.sourceType,
+    sourceUrl: node.properties.sourceUrl,
+    retrievedAt: node.properties.retrievedAt,
+    situation: node.properties.situation,
+    identifiers: {},
+  };
+  for (const relationship of relationships) {
+    if (relationship.startNode !== node.id) {
+      continue;
+    }
+    const target = nodeById.get(relationship.endNode);
+    const wikidataIdValue = target?.properties?.wikidataId;
+    if (relationship.type === 'HAS_WIKIDATA_SUBJECT') {
+      record.identifiers.subject = wikidataIdValue;
+    } else if (relationship.type === 'HAS_WIKIDATA_PROPERTY') {
+      record.identifiers.property = wikidataIdValue;
+    } else if (relationship.type === 'HAS_WIKIDATA_OBJECT') {
+      record.identifiers.object = wikidataIdValue;
+    } else if (relationship.type === 'DERIVED_FROM') {
+      record.sourceUrl = target?.properties?.url ?? record.sourceUrl;
+    }
+  }
+  return record;
+}
+
+function sparqlScopeRecord(record) {
+  const subject = wikidataId(record.identifiers.subject, 'Q');
+  const property = wikidataId(record.identifiers.property, 'P');
+  if (!subject || !property) {
+    return null;
+  }
+  return {
+    ...record,
+    subject,
+    property,
+    object: wikidataId(record.identifiers.object, 'Q'),
+  };
+}
+
+function createSparqlScope(records) {
+  return {
+    evidenceRecords: unique(
+      records.map((record) => record.linksNotationLinkId)
+    ),
+    templates: unique(
+      records.map((record) => record.situation).filter(Boolean)
+    ),
+    subjects: unique(records.map((record) => record.subject)),
+    properties: unique(records.map((record) => record.property)),
+    objects: unique(records.map((record) => record.object).filter(Boolean)),
+  };
+}
+
+function createScopedSparqlQuery(records, model) {
+  const rows = records.map(sparqlValuesRow);
+  const values =
+    rows.length > 0 ? rows.map((row) => `    ${row}`).join('\n') : '';
+  return [
+    '# Scoped meta-expression evidence export.',
+    `# sourceSurface: ${model.sourceSurface}`,
+    `# exportedAt: ${model.exportedAt}`,
+    `# boundedConfidence: ${model.guardrails.boundedConfidence ?? 'null'}`,
+    'PREFIX wd: <http://www.wikidata.org/entity/>',
+    'PREFIX wdt: <http://www.wikidata.org/prop/direct/>',
+    'PREFIX meta: <https://link-assistant.github.io/meta-expression/vocab#>',
+    'PREFIX prov: <http://www.w3.org/ns/prov#>',
+    'PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>',
+    '',
+    'CONSTRUCT {',
+    '  ?evidence meta:wikidataSubject ?subject ;',
+    '    meta:wikidataProperty ?property ;',
+    '    meta:wikidataObject ?object ;',
+    '    meta:polarity ?polarity ;',
+    '    meta:boundedConfidence ?boundedConfidence ;',
+    '    prov:wasDerivedFrom ?source .',
+    '  ?subject ?property ?object .',
+    '} WHERE {',
+    '  VALUES (?subject ?property ?object ?evidence ?source ?polarity ?boundedConfidence) {',
+    values,
+    '  }',
+    '}',
+    `LIMIT ${model.limit}`,
+  ].join('\n');
+}
+
+function sparqlValuesRow(record) {
+  const object = record.object ? `wd:${record.object}` : 'UNDEF';
+  const source = record.sourceUrl ? iri(record.sourceUrl) : 'UNDEF';
+  return [
+    '(',
+    `wd:${record.subject}`,
+    `wdt:${record.property}`,
+    object,
+    iri(record.id),
+    source,
+    stringLiteral(record.polarity),
+    decimalLiteral(record.guardrails?.boundedConfidence),
+    ')',
+  ].join(' ');
+}
+
+function sparqlPrefixes() {
+  return {
+    meta: metaNamespace,
+    prov: provNamespace,
+    rdf: rdfNamespace,
+    xsd: xsdNamespace,
+    wd: wikidataEntityPrefix,
+    wdt: wikidataDirectPrefix,
+  };
+}
+
+function guardrailsForResult(result = {}) {
+  const rawConfidence = nullableNumber(result.calculation?.rawConfidence);
+  const boundedConfidence = nullableNumber(result.confidence);
+  return {
+    boundedConfidence,
+    rawConfidence,
+    confidence: boundedConfidence,
+    correctness: nullableNumber(result.correctness),
+    signedConfidence: nullableNumber(result.signedConfidence),
+    bounded:
+      result.calculation?.bounded === true ||
+      (rawConfidence !== null &&
+        boundedConfidence !== null &&
+        rawConfidence !== boundedConfidence),
+    realWorldUncertainty: nullableNumber(
+      result.calculation?.realWorldUncertainty
+    ),
+  };
+}
+
+function combinedGuardrails(analyses) {
+  if (analyses.length === 1) {
+    return analyses[0].guardrails;
+  }
+  return {
+    boundedConfidence: null,
+    rawConfidence: null,
+    confidence: null,
+    correctness: null,
+    signedConfidence: null,
+    bounded: analyses.some((analysis) => analysis.guardrails.bounded),
+    realWorldUncertainty: null,
+    analyses: analyses.map((analysis) => ({
+      id: analysis.id,
+      ...analysis.guardrails,
+    })),
+  };
+}
+
+function createExportProvenance(model) {
+  return {
+    baseId: model.baseId,
+    generatedBy: 'meta-expression',
+    sourceSurface: model.sourceSurface,
+    exportedAt: model.exportedAt,
+    linksNotation: model.linksNotation,
+  };
+}
+
+function validateGraphInput(input, sourceSurface) {
+  if (sourceSurface === 'check') {
+    if (!Array.isArray(input.statements)) {
+      throw new Error(
+        'Graph evidence export requires analysis or check output.'
+      );
+    }
+    return;
+  }
+  if (input?.status !== 'completed') {
+    throw new Error('Graph evidence export requires analysis or check output.');
+  }
+}
+
+function linksNotationFor(input, sourceSurface) {
+  if (sourceSurface === 'check') {
+    return input.linksNotation ?? '';
+  }
+  return input.linksNetwork ? serializeLinksNotation(input.linksNetwork) : '';
+}
+
+function addNode(nodes, node) {
+  if (!nodes.has(node.id)) {
+    nodes.set(node.id, node);
+  }
+}
+
+function addRelationship(graph, startNode, endNode, type, properties) {
+  graph.relationships.push({
+    id: `${safeReference(type)}-${graph.relationships.length + 1}`,
+    type,
+    startNode,
+    endNode,
+    properties,
+  });
+}
+
+function iriTriple(subject, predicate, object, record) {
+  return triple(subject, predicate, { type: 'iri', value: object }, record);
+}
+
+function literalTriple(subject, predicate, value, datatype, record) {
+  return triple(
+    subject,
+    predicate,
+    {
+      type: 'literal',
+      value,
+      datatype,
+    },
+    record
+  );
+}
+
+function triple(subject, predicate, object, record) {
+  return {
+    subject,
+    predicate,
+    object,
+    provenance: record
+      ? {
+          linksNotationLinkId: record.linksNotationLinkId,
+          sourceUrl: record.sourceUrl,
+          retrievedAt: record.retrievedAt,
+        }
+      : undefined,
+  };
+}
+
+function normalizeLimit(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return defaultLimit;
+  }
+  return Math.max(1, Math.min(Math.floor(parsed), maxLimit));
+}
+
+function surfaceKey(input) {
+  if (input?.status === 'checked') {
+    return shortHash(input.markdown ?? input.linksNotation ?? 'check');
+  }
+  return safeReference(input?.statement?.value?.text ?? 'analysis');
+}
+
+function normalizeBaseId(value) {
+  return String(value ?? 'urn:meta-expression:graph').replace(/[#/]+$/u, '');
+}
+
+function nodeId(baseId, fragment) {
+  return `${baseId}#${safeReference(fragment)}`;
+}
+
+function timestampFrom(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return new Date(value).toISOString();
+}
+
+function situationId(value) {
+  if (!value) {
+    return null;
+  }
+  return typeof value === 'string' ? value : stringValue(value.id);
+}
+
+function wikidataId(value, prefix) {
+  const text = String(value ?? '').trim();
+  return new RegExp(`^${prefix}\\d+$`, 'u').test(text) ? text : null;
+}
+
+function compactWikidataId(value) {
+  return String(value ?? '')
+    .replace(/^wd:/u, '')
+    .replace(/^wdt:/u, '')
+    .replace(wikidataEntityPrefix, '')
+    .replace(wikidataDirectPrefix, '');
+}
+
+function wikidataIri(id) {
+  return id.startsWith('P')
+    ? `${wikidataDirectPrefix}${id}`
+    : `${wikidataEntityPrefix}${id}`;
+}
+
+function decimalLiteral(value) {
+  return value === null || value === undefined
+    ? 'UNDEF'
+    : `"${Number(value)}"^^xsd:decimal`;
+}
+
+function stringLiteral(value) {
+  return `"${String(value ?? '')
+    .replace(/\\/gu, '\\\\')
+    .replace(/"/gu, '\\"')
+    .replace(/\r/gu, '\\r')
+    .replace(/\n/gu, '\\n')}"`;
+}
+
+function iri(value) {
+  return `<${String(value).replace(/[<>"{}|^`\\]/gu, encodeURIComponent)}>`;
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function nullableNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function finiteNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function stringValue(value) {
+  return typeof value === 'string' && value ? value : '';
+}
+
+function jsonCompatible(value) {
+  return JSON.parse(JSON.stringify(value ?? {}));
+}
+
+function safeReference(value) {
+  return (
+    String(value)
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'value'
+  );
+}
+
+function shortHash(value) {
+  let hash = 0;
+  for (const char of String(value)) {
+    hash = (hash * 31 + char.codePointAt(0)) >>> 0;
+  }
+  return hash.toString(36);
+}

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1901,6 +1901,10 @@ export interface EvidenceProvenanceExportOptions {
   linksNotation?: string;
 }
 
+export interface EvidenceGraphExportOptions extends EvidenceProvenanceExportOptions {
+  limit?: number;
+}
+
 export interface EvidenceJsonLdExport extends Record<string, unknown> {
   '@context': Record<string, unknown>;
   '@id': string;
@@ -1923,6 +1927,35 @@ export interface EvidenceProvJsonLdExport extends Record<string, unknown> {
   exportedAt: string;
   linksNotation: string;
   '@graph': Record<string, unknown>[];
+}
+
+export interface EvidenceRdfTriplesExport extends Record<string, unknown> {
+  format: 'meta-expression-rdf-triples';
+  sourceSurface: 'analyze' | 'check';
+  exportedAt: string;
+  triples: Record<string, unknown>[];
+  mappings: Record<string, string>[];
+  guardrails: Record<string, unknown> | null;
+}
+
+export interface EvidencePropertyGraphExport extends Record<string, unknown> {
+  format: 'meta-expression-property-graph';
+  sourceSurface: 'analyze' | 'check';
+  exportedAt: string;
+  nodes: Record<string, unknown>[];
+  relationships: Record<string, unknown>[];
+  mappings: Record<string, string>[];
+  guardrails: Record<string, unknown> | null;
+}
+
+export interface ScopedSparqlEvidenceExport extends Record<string, unknown> {
+  format: 'meta-expression-scoped-sparql';
+  sourceSurface: 'analyze' | 'check';
+  exportedAt: string;
+  query: string;
+  scope: Record<string, unknown>;
+  limits: Record<string, unknown>;
+  guardrails: Record<string, unknown> | null;
 }
 
 export type UniquenessSuggestedAction =
@@ -2204,6 +2237,29 @@ export declare function exportEvidenceProvJsonLd(
   input: StatementAnalysis | CheckResult,
   options?: EvidenceProvenanceExportOptions
 ): EvidenceProvJsonLdExport;
+
+export declare function exportScopedSparqlEvidence(
+  input: StatementAnalysis | CheckResult,
+  options?: EvidenceGraphExportOptions
+): ScopedSparqlEvidenceExport;
+
+export declare function exportEvidenceRdfTriples(
+  input: StatementAnalysis | CheckResult,
+  options?: EvidenceGraphExportOptions
+): EvidenceRdfTriplesExport;
+
+export declare function importEvidenceRdfTriples(
+  input: EvidenceRdfTriplesExport | Record<string, unknown>
+): Record<string, unknown>;
+
+export declare function exportEvidencePropertyGraph(
+  input: StatementAnalysis | CheckResult,
+  options?: EvidenceGraphExportOptions
+): EvidencePropertyGraphExport;
+
+export declare function importEvidencePropertyGraph(
+  input: EvidencePropertyGraphExport | Record<string, unknown>
+): Record<string, unknown>;
 
 export declare function searchTextUniqueness(
   input: string,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -115,6 +115,13 @@ export {
   exportEvidenceProvJsonLd,
 } from './provenance-jsonld.js';
 export {
+  exportEvidencePropertyGraph,
+  exportEvidenceRdfTriples,
+  exportScopedSparqlEvidence,
+  importEvidencePropertyGraph,
+  importEvidenceRdfTriples,
+} from './graph-interchange.js';
+export {
   createLiteratureEvidenceItems,
   exportLiteratureBibliography,
   exportLiteratureBibTeX,

--- a/js/src/server.js
+++ b/js/src/server.js
@@ -3,8 +3,11 @@ import { URL, fileURLToPath } from 'node:url';
 import {
   analyzeStatement,
   analyzeStatementWithLiveEvidence,
+  exportEvidencePropertyGraph,
   exportEvidenceJsonLd,
   exportEvidenceProvJsonLd,
+  exportEvidenceRdfTriples,
+  exportScopedSparqlEvidence,
   naturalizeExpressionWith,
   serializeLinksNotation,
 } from './index.js';
@@ -138,6 +141,7 @@ function analyzeParamsFromSearch(url) {
     url.searchParams.get('format') ?? 'json',
     Number(url.searchParams.get('select') ?? 0),
     url.searchParams.get('live') === 'true',
+    numberParam(url.searchParams.get('limit')),
   ];
 }
 
@@ -147,6 +151,7 @@ function analyzeParamsFromPayload(payload) {
     payload.format ?? 'json',
     payload.interpretationIndex ?? 0,
     payload.live === true,
+    payload.limit,
   ];
 }
 
@@ -231,6 +236,7 @@ function checkParamsFromSearch(url) {
     input: url.searchParams.get('input') ?? '',
     format: url.searchParams.get('format') ?? 'json',
     live: url.searchParams.get('live') === 'true',
+    limit: numberParam(url.searchParams.get('limit')),
     evidenceScoring: evidenceScoringFromSearch(url),
     sourceUrl:
       url.searchParams.get('sourceUrl') ?? url.searchParams.get('source') ?? '',
@@ -242,6 +248,7 @@ function checkParamsFromPayload(payload) {
     input: payload.input ?? '',
     format: payload.format ?? 'json',
     live: payload.live === true,
+    limit: payload.limit,
     evidenceScoring: payload.evidenceScoring,
     preferenceProfile: payload.preferenceProfile,
     sourceUrl: payload.sourceUrl ?? payload.source ?? '',
@@ -309,7 +316,8 @@ async function sendAnalysis(
   input,
   format,
   interpretationIndex,
-  live
+  live,
+  limit
 ) {
   const options = {
     interpretationIndex,
@@ -319,6 +327,22 @@ async function sendAnalysis(
     ? await analyzeStatementWithLiveEvidence(input, options)
     : analyzeStatement(input, options);
 
+  if (isSparqlFormat(format)) {
+    sendSparqlQuery(
+      response,
+      200,
+      exportScopedSparqlEvidence(analysis, { limit }).query
+    );
+    return;
+  }
+  if (isPropertyGraphFormat(format)) {
+    sendJson(response, 200, exportEvidencePropertyGraph(analysis, { limit }));
+    return;
+  }
+  if (isRdfFormat(format)) {
+    sendJson(response, 200, exportEvidenceRdfTriples(analysis, { limit }));
+    return;
+  }
   if (isProvOFormat(format)) {
     sendLinkedDataJson(response, 200, exportEvidenceProvJsonLd(analysis));
     return;
@@ -443,6 +467,7 @@ async function sendCheck(response, params, ctx) {
     ? await checkTextWithLiveEvidence(params.input, options)
     : checkText(params.input, options);
   emitCheckResponse(response, params.format, result, {
+    limit: params.limit,
     sourceUrl: params.sourceUrl,
   });
 }
@@ -584,6 +609,30 @@ function emitCheckResponse(response, format, payload, options = {}) {
     );
     return 0;
   }
+  if (isSparqlFormat(format)) {
+    sendSparqlQuery(
+      response,
+      200,
+      exportScopedSparqlEvidence(payload, { limit: options.limit }).query
+    );
+    return 0;
+  }
+  if (isPropertyGraphFormat(format)) {
+    sendJson(
+      response,
+      200,
+      exportEvidencePropertyGraph(payload, { limit: options.limit })
+    );
+    return 0;
+  }
+  if (isRdfFormat(format)) {
+    sendJson(
+      response,
+      200,
+      exportEvidenceRdfTriples(payload, { limit: options.limit })
+    );
+    return 0;
+  }
   if (isProvOFormat(format)) {
     sendLinkedDataJson(response, 200, exportEvidenceProvJsonLd(payload));
     return 0;
@@ -619,6 +668,18 @@ function emitCheckResponse(response, format, payload, options = {}) {
 
 function isClaimReviewFormat(format) {
   return format === 'claim-review' || format === 'claimreview';
+}
+
+function isSparqlFormat(format) {
+  return format === 'sparql' || format === 'sparql-query';
+}
+
+function isPropertyGraphFormat(format) {
+  return format === 'property-graph' || format === 'graph';
+}
+
+function isRdfFormat(format) {
+  return format === 'rdf' || format === 'rdf-triples';
 }
 
 function isJsonLdFormat(format) {
@@ -677,6 +738,13 @@ function sendLinkedDataJson(response, status, payload) {
     'content-type': 'application/ld+json; charset=utf-8',
   });
   response.end(JSON.stringify(payload, null, 2));
+}
+
+function sendSparqlQuery(response, status, query) {
+  response.writeHead(status, {
+    'content-type': 'application/sparql-query; charset=utf-8',
+  });
+  response.end(query);
 }
 
 function readRequestBody(request) {

--- a/js/tests/integration/issue-92-graph-interop.test.js
+++ b/js/tests/integration/issue-92-graph-interop.test.js
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'test-anywhere';
+import {
+  analyzeStatement,
+  checkText,
+  exportEvidencePropertyGraph,
+  exportEvidenceRdfTriples,
+  exportScopedSparqlEvidence,
+  importEvidencePropertyGraph,
+  importEvidenceRdfTriples,
+} from '../../src/index.js';
+import { runCliAsync } from '../../src/cli.js';
+import { createMetaExpressionServer } from '../../src/server.js';
+
+const exportedAt = '2026-05-26T12:00:00.000Z';
+
+describe('issue 92 - scoped SPARQL and graph-database interchange', () => {
+  it('exports selected Q/P evidence templates as a scoped SPARQL CONSTRUCT query with limits and provenance', () => {
+    const analysis = analyzeStatement('Earth orbits the Sun');
+    const sparql = exportScopedSparqlEvidence(analysis, {
+      baseId: 'https://example.org/meta-expression/cases/earth-orbits-sun',
+      exportedAt,
+      limit: 5,
+    });
+
+    expect(sparql.format).toBe('meta-expression-scoped-sparql');
+    expect(sparql.sourceSurface).toBe('analyze');
+    expect(sparql.limits.maxEvidenceRecords).toBe(5);
+    expect(sparql.scope.subjects).toEqual(['Q2']);
+    expect(sparql.scope.properties).toEqual(['P397']);
+    expect(sparql.scope.objects).toEqual(['Q525']);
+    expect(sparql.scope.templates).toEqual(['wikidata-structured-claim']);
+    expect(sparql.provenance.generatedBy).toBe('meta-expression');
+    expect(sparql.provenance.linksNotation).toContain('links-network');
+    expect(sparql.guardrails.boundedConfidence).toBe(
+      analysis.result.confidence
+    );
+    expect(sparql.guardrails.boundedConfidence).toBeLessThan(1);
+    expect(sparql.query).toContain('CONSTRUCT');
+    expect(sparql.query).toContain(
+      'VALUES (?subject ?property ?object ?evidence ?source ?polarity ?boundedConfidence)'
+    );
+    expect(sparql.query).toContain('wd:Q2');
+    expect(sparql.query).toContain('wdt:P397');
+    expect(sparql.query).toContain('wd:Q525');
+    expect(sparql.query).toContain('LIMIT 5');
+  });
+
+  it('maps Links Notation evidence links to RDF triples and back', () => {
+    const analysis = analyzeStatement('Earth orbits the Sun');
+    const evidenceLink = analysis.linksNetwork.links.find(
+      (link) => link.role === 'evidence'
+    );
+    const rdf = exportEvidenceRdfTriples(analysis, {
+      baseId: 'https://example.org/meta-expression/cases/earth-orbits-sun',
+      exportedAt,
+    });
+    const imported = importEvidenceRdfTriples(rdf);
+
+    expect(rdf.format).toBe('meta-expression-rdf-triples');
+    expect(rdf.mappings[0].linksNotationLinkId).toBe(evidenceLink.id);
+    expect(
+      rdf.triples.some(
+        (triple) =>
+          triple.predicate === 'meta:wikidataSubject' &&
+          triple.object.value === 'wd:Q2'
+      )
+    ).toBe(true);
+    expect(
+      rdf.triples.some(
+        (triple) =>
+          triple.predicate === 'meta:wikidataProperty' &&
+          triple.object.value === 'wdt:P397'
+      )
+    ).toBe(true);
+    expect(imported.evidenceRecords[0].identifiers).toEqual({
+      subject: 'Q2',
+      property: 'P397',
+      object: 'Q525',
+    });
+    expect(imported.guardrails.boundedConfidence).toBe(
+      analysis.result.confidence
+    );
+  });
+
+  it('applies scoped SPARQL limits after counting available Q/P evidence', () => {
+    const checked = checkText(
+      'Earth orbits the Sun. Paris is the capital of France.'
+    );
+    const sparql = exportScopedSparqlEvidence(checked, {
+      exportedAt,
+      limit: 1,
+    });
+
+    expect(sparql.sourceSurface).toBe('check');
+    expect(sparql.limits.availableEvidenceRecords).toBeGreaterThan(1);
+    expect(sparql.limits.selectedEvidenceRecords).toBe(1);
+    expect(sparql.limits.truncated).toBe(true);
+    expect(sparql.scope.subjects).toEqual(['Q2']);
+    expect(sparql.query).toContain('LIMIT 1');
+  });
+
+  it('maps Links Notation evidence links to a graph-database property graph and back', () => {
+    const analysis = analyzeStatement('Earth orbits the Sun');
+    const propertyGraph = exportEvidencePropertyGraph(analysis, {
+      baseId: 'https://example.org/meta-expression/cases/earth-orbits-sun',
+      exportedAt,
+    });
+    const imported = importEvidencePropertyGraph(propertyGraph);
+
+    expect(propertyGraph.format).toBe('meta-expression-property-graph');
+    expect(
+      propertyGraph.nodes.some(
+        (node) =>
+          node.labels.includes('WikidataEntity') &&
+          node.properties.wikidataId === 'Q2'
+      )
+    ).toBe(true);
+    expect(
+      propertyGraph.nodes.some(
+        (node) =>
+          node.labels.includes('WikidataProperty') &&
+          node.properties.wikidataId === 'P397'
+      )
+    ).toBe(true);
+    expect(
+      propertyGraph.relationships.some(
+        (relationship) => relationship.type === 'HAS_WIKIDATA_SUBJECT'
+      )
+    ).toBe(true);
+    expect(imported.evidenceRecords[0].sourceType).toBe('wikidata');
+    expect(imported.evidenceRecords[0].identifiers.property).toBe('P397');
+  });
+
+  it('does not let generic graph export bypass bounded-confidence guardrails', () => {
+    const analysis = analyzeStatement('Earth orbits the Sun', {
+      evidenceScoring: { 'wikidata-structured-claim': 1 },
+      realWorldUncertainty: 0.2,
+    });
+    const rdf = exportEvidenceRdfTriples(analysis);
+    const propertyGraph = exportEvidencePropertyGraph(analysis);
+    const analysisNode = propertyGraph.nodes.find((node) =>
+      node.labels.includes('Analysis')
+    );
+
+    expect(analysis.result.calculation.rawConfidence).toBe(1);
+    expect(analysis.result.confidence).toBe(0.8);
+    expect(rdf.guardrails.rawConfidence).toBe(1);
+    expect(rdf.guardrails.boundedConfidence).toBe(0.8);
+    expect(propertyGraph.guardrails.rawConfidence).toBe(1);
+    expect(propertyGraph.guardrails.boundedConfidence).toBe(0.8);
+    expect(analysisNode.properties.confidence).toBe(0.8);
+    expect(importEvidencePropertyGraph(propertyGraph).guardrails).toEqual(
+      propertyGraph.guardrails
+    );
+  });
+
+  registerSurfaceExportTests();
+});
+
+function registerSurfaceExportTests() {
+  it('supports scoped SPARQL exports from CLI and HTTP analyze surfaces', async () => {
+    const output = {
+      logs: [],
+      errors: [],
+      log(value) {
+        this.logs.push(value);
+      },
+      error(value) {
+        this.errors.push(value);
+      },
+    };
+    const exitCode = await runCliAsync(
+      [
+        'analyze',
+        '--input',
+        'Earth orbits the Sun',
+        '--format',
+        'sparql',
+        '--limit',
+        '3',
+      ],
+      output
+    );
+    const started = await startServer();
+
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${started.port}/analyze?input=${encodeURIComponent(
+          'Earth orbits the Sun'
+        )}&format=sparql&limit=4`
+      );
+      const body = await response.text();
+
+      expect(exitCode).toBe(0);
+      expect(output.errors).toEqual([]);
+      expect(output.logs[0]).toContain('LIMIT 3');
+      expect(output.logs[0]).toContain('wdt:P397');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toContain(
+        'application/sparql-query'
+      );
+      expect(body).toContain('LIMIT 4');
+    } finally {
+      await stopServer(started.server);
+    }
+  });
+}
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const server = createMetaExpressionServer({
+      cacheRoot: '.cache/issue-92-test',
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}


### PR DESCRIPTION
## What

- Adds scoped SPARQL `CONSTRUCT` export for selected Wikidata Q/P evidence with explicit record limits, provenance, and bounded-confidence metadata.
- Adds RDF-triple and property-graph interchange shapes, plus import helpers that map those shapes back to Links Notation evidence records.
- Wires the new graph export formats through public library exports, CLI, HTTP `/analyze` and `/check`, TypeScript declarations, README docs, and a changeset.

## Why

Fixes #92.

## How To Reproduce

Before this PR, graph evidence interchange was unavailable from the library, CLI, and HTTP surfaces.

```bash
node js/src/cli.js analyze --input "Earth orbits the Sun" --format sparql --limit 5
node js/src/cli.js analyze --input "Earth orbits the Sun" --format property-graph
```

## Testing

```bash
node --test js/tests/integration/issue-92-graph-interop.test.js
npm test
npm run check
bash scripts/check-file-line-limits.sh
```

`scripts/check-file-line-limits.sh` passes with only existing warning-threshold files reported; all checked files remain under the 1500-line limit.