### PR TITLE
feat: add proof and solver artifact adapters

### DIFF
--- a/.changeset/issue-93-proof-solver-artifacts.md
+++ b/.changeset/issue-93-proof-solver-artifacts.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': minor
+---
+
+Add proof and solver artifact adapters that normalize Lean 4 and SMT-LIB fixtures into bounded provenance-bearing evidence.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
 # Updated: 2026-05-26T06:39:16.671Z
 # Updated: 2026-05-26T06:58:24.996Z
-# Updated: 2026-05-26T07:19:09.365Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
 # Updated: 2026-05-26T06:39:16.671Z
 # Updated: 2026-05-26T06:58:24.996Z
+# Updated: 2026-05-26T07:19:09.365Z

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Core exports:
   and `exportEvidencePropertyGraph(result)` project existing Q/P evidence links
   into scoped SPARQL, RDF-triple, and property-graph interchange shapes without
   changing the bounded real-world confidence calculation.
+- `collectProofSolverArtifactEvidence(input, { artifacts })` normalizes Lean 4
+  proof snippets and SMT-LIB solver outputs into provenance-bearing, bounded
+  evidence items that can be passed to `analyzeStatement(..., { evidence })`.
 - `reviewClaimAgainstLiterature(fixture)` checks a claim against screened paper
   metadata/excerpts as normal evidence links, reports literature agreement and
   uncertainty, and `exportLiteratureBibliography(result, { format })` emits

--- a/docs/case-studies/issue-93/README.md
+++ b/docs/case-studies/issue-93/README.md
@@ -1,0 +1,45 @@
+# Issue 93: Proof and Solver Artifact Adapters
+
+Issue: <https://github.com/link-assistant/meta-expression/issues/93>
+PR: <https://github.com/link-assistant/meta-expression/pull/105>
+
+## Summary
+
+Issue 93 adds a library surface for importing external proof-assistant and
+solver/query artifacts as provenance-bearing evidence. The initial adapters
+normalize Lean 4 proof snippets and SMT-LIB solver results into a shared
+`proof-solver-artifact-evidence` bundle.
+
+The adapters do not execute Lean, Z3, Prolog, Datalog, Metamath, or other
+external engines. They validate artifact shape, preserve the reported checker or
+solver result, and emit bounded evidence items that can be supplied to
+`analyzeStatement(..., { evidence })`.
+
+## Guardrail
+
+The data model records:
+
+- the external format and system;
+- the artifact text and reported outcome;
+- adapter provenance and retrieval/check timestamps;
+- `executionGate.issue === 72`;
+- `truthScoring.absolute === false`.
+
+This keeps issue #72 as the execution/parity-test gate while issue #93 owns the
+adapter and evidence data model.
+
+## Fixtures
+
+Regression fixtures live in
+[`js/tests/fixtures/issue-93/proof-solver-artifacts.json`](../../../js/tests/fixtures/issue-93/proof-solver-artifacts.json):
+
+- Lean 4: `example : 1 + 1 = 2 := rfl`
+- SMT-LIB: a negated arithmetic equality query with reported `unsat`
+
+## Verification
+
+Focused regression:
+
+```bash
+node --test js/tests/integration/issue-93-proof-solver-artifacts.test.js
+```

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -177,6 +177,121 @@ export interface RelativeMetaLogicInputMapping {
   engine: RelativeMetaLogicUpstream;
 }
 
+export type ProofSolverArtifactFormat = 'lean4' | 'smt-lib';
+
+export type ProofSolverArtifactStatus =
+  | 'candidate'
+  | 'validated'
+  | 'unsupported';
+
+export interface ProofSolverArtifactAdapter {
+  id: string;
+  name: string;
+  kind: string;
+  formats: string[];
+  sourceType: string;
+  version?: string | null;
+  adapt(raw: unknown, context?: Record<string, unknown>): ProofSolverArtifact;
+}
+
+export interface ProofSolverSourceAdapter {
+  id?: string;
+  name?: string;
+  kind?: string;
+  sourceType?: string;
+  version?: string | null;
+  extract(
+    claimText: string,
+    context: Record<string, unknown>
+  ): unknown | Promise<unknown>;
+}
+
+export interface ProofSolverArtifact {
+  id: string;
+  family: 'proof-assistant' | 'solver-query' | string;
+  format: ProofSolverArtifactFormat | string;
+  system: string;
+  adapterId: string;
+  claim: {
+    text: string;
+    key: string;
+  };
+  artifact: {
+    language: string;
+    entrypoint: string | null;
+    intent: string | null;
+    text: string;
+  };
+  result: {
+    kind: 'proof' | 'solver-result' | string;
+    outcome: string | null;
+    polarity: EvidenceItem['polarity'] | null;
+    checker: string | null;
+    mode: string;
+    checkedAt: string;
+    absolute: false;
+  };
+  provenance: LinkProvenance & {
+    adapterId: string;
+    adapterVersion: string | null;
+  };
+  verification: {
+    executed: false;
+    executionGate: {
+      issue: 72;
+      label: string;
+      url: string;
+    };
+    checks: Array<{ id: string; passed: boolean; message: string }>;
+    diagnostics: Array<{ level: string; message: string }>;
+  };
+  status: ProofSolverArtifactStatus;
+  truthScoring: {
+    included: boolean;
+    eligible: boolean;
+    absolute: false;
+    maxEvidenceWeight: number;
+    executionGate: {
+      issue: 72;
+      label: string;
+      url: string;
+    };
+    reason: string;
+  };
+  evidence: EvidenceItem | null;
+}
+
+export interface ProofSolverArtifactEvidenceBundle {
+  type: 'proof-solver-artifact-evidence';
+  version: 1;
+  status: 'evidence-only' | 'empty';
+  claim: {
+    text: string;
+    key: string;
+  };
+  guardrails: {
+    executionGate: {
+      issue: 72;
+      label: string;
+      url: string;
+    };
+    absoluteClaims: false;
+    defaultMaxEvidenceWeight: number;
+    reason: string;
+  };
+  adapters: Array<{
+    id: string;
+    name: string;
+    kind: string;
+    formats: string[];
+    sourceType: string;
+    version: string | null;
+  }>;
+  artifacts: ProofSolverArtifact[];
+  evidence: EvidenceItem[];
+  diagnostics: Array<{ id: string; level: string; message: string }>;
+}
+
 export interface FormalReasoningDependency {
   source: string;
   target: string;
@@ -631,6 +746,40 @@ export declare const RELATIVE_META_LOGIC_UPSTREAM: RelativeMetaLogicUpstream;
 export declare function mapFormalizationToRelativeMetaLogicInput(
   formalization: Formalization
 ): RelativeMetaLogicInputMapping;
+
+export declare const PROOF_SOLVER_ARTIFACT_FORMATS: {
+  readonly LEAN4: 'lean4';
+  readonly SMT_LIB: 'smt-lib';
+};
+
+export declare const PROOF_SOLVER_ARTIFACT_STATUS: {
+  readonly CANDIDATE: 'candidate';
+  readonly VALIDATED: 'validated';
+  readonly UNSUPPORTED: 'unsupported';
+};
+
+export declare function createLeanProofArtifactAdapter(
+  options?: Partial<ProofSolverArtifactAdapter>
+): ProofSolverArtifactAdapter;
+
+export declare function createSmtLibSolverArtifactAdapter(
+  options?: Partial<ProofSolverArtifactAdapter>
+): ProofSolverArtifactAdapter;
+
+export declare function createFixtureProofSolverArtifactAdapter(
+  fixture: unknown
+): ProofSolverSourceAdapter;
+
+export declare function collectProofSolverArtifactEvidence(
+  claimText: string,
+  options?: {
+    artifacts?: unknown | unknown[];
+    adapters?: Array<ProofSolverArtifactAdapter | ProofSolverSourceAdapter>;
+    sourceAdapters?: ProofSolverSourceAdapter | ProofSolverSourceAdapter[];
+    maxEvidenceWeight?: number;
+    now?: () => number | string | Date;
+  }
+): Promise<ProofSolverArtifactEvidenceBundle>;
 
 export declare function isFormalReasoningInput(input: unknown): boolean;
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -176,6 +176,14 @@ export {
   mapFormalizationToRelativeMetaLogicInput,
 } from './relative-meta-logic-adapter.js';
 export {
+  PROOF_SOLVER_ARTIFACT_FORMATS,
+  PROOF_SOLVER_ARTIFACT_STATUS,
+  collectProofSolverArtifactEvidence,
+  createFixtureProofSolverArtifactAdapter,
+  createLeanProofArtifactAdapter,
+  createSmtLibSolverArtifactAdapter,
+} from './proof-solver-artifacts.js';
+export {
   createDefaultPreferenceProfile,
   createPreferenceEvidence,
   getPreferenceEvidenceSituationProbability,

--- a/js/src/preferences.js
+++ b/js/src/preferences.js
@@ -152,6 +152,12 @@ export const preferenceEvidenceSituationDefinitions = Object.freeze([
     group: 'knowledge-source',
     defaultProbability: 1,
   }),
+  Object.freeze({
+    id: 'external-proof-solver-artifact',
+    label: 'External proof or solver artifact',
+    group: 'knowledge-source',
+    defaultProbability: 1,
+  }),
 ]);
 
 const defaultPreferenceProfile = Object.freeze({

--- a/js/src/proof-solver-artifacts.js
+++ b/js/src/proof-solver-artifacts.js
@@ -1,0 +1,612 @@
+export const PROOF_SOLVER_ARTIFACT_FORMATS = Object.freeze({
+  LEAN4: 'lean4',
+  SMT_LIB: 'smt-lib',
+});
+
+export const PROOF_SOLVER_ARTIFACT_STATUS = Object.freeze({
+  CANDIDATE: 'candidate',
+  VALIDATED: 'validated',
+  UNSUPPORTED: 'unsupported',
+});
+
+const issue72Gate = Object.freeze({
+  issue: 72,
+  label: 'execution-parity-gate',
+  url: 'https://github.com/link-assistant/meta-expression/issues/72',
+});
+const defaultMaxEvidenceWeight = 0.9;
+const artifactSituation = 'external-proof-solver-artifact';
+const boundedEvidenceReason =
+  'External proof and solver artifacts are recorded as bounded evidence; local execution and parity validation stay behind issue #72.';
+
+export function createLeanProofArtifactAdapter(options = {}) {
+  return {
+    id: options.id ?? 'lean4-proof-artifact-adapter',
+    name: options.name ?? 'Lean 4 proof artifact adapter',
+    kind: options.kind ?? 'proof-assistant',
+    formats: options.formats ?? ['lean4', 'lean'],
+    sourceType: options.sourceType ?? 'proof-assistant-artifact',
+    version: options.version ?? '1',
+    adapt(raw, context = {}) {
+      return normalizeArtifact(raw, context, {
+        adapter: this,
+        family: 'proof-assistant',
+        defaultFormat: PROOF_SOLVER_ARTIFACT_FORMATS.LEAN4,
+        resultKind: 'proof',
+        checks: validateLeanArtifact(raw),
+      });
+    },
+  };
+}
+
+export function createSmtLibSolverArtifactAdapter(options = {}) {
+  return {
+    id: options.id ?? 'smt-lib-solver-artifact-adapter',
+    name: options.name ?? 'SMT-LIB solver artifact adapter',
+    kind: options.kind ?? 'solver-query',
+    formats: options.formats ?? ['smt-lib', 'smtlib', 'smt2'],
+    sourceType: options.sourceType ?? 'solver-artifact',
+    version: options.version ?? '1',
+    adapt(raw, context = {}) {
+      return normalizeArtifact(raw, context, {
+        adapter: this,
+        family: 'solver-query',
+        defaultFormat: PROOF_SOLVER_ARTIFACT_FORMATS.SMT_LIB,
+        resultKind: 'solver-result',
+        checks: validateSmtLibArtifact(raw),
+      });
+    },
+  };
+}
+
+export function createFixtureProofSolverArtifactAdapter(fixture) {
+  const descriptor = Array.isArray(fixture) ? {} : (fixture ?? {});
+  return {
+    id: descriptor.id ?? 'fixture-proof-solver-artifact-adapter',
+    name:
+      descriptor.name ??
+      descriptor.id ??
+      'Fixture proof and solver artifact adapter',
+    kind: descriptor.kind ?? 'fixture',
+    sourceType: descriptor.sourceType ?? 'proof-solver-fixture',
+    version: descriptor.version ?? null,
+    extract() {
+      return Promise.resolve(fixture);
+    },
+  };
+}
+
+export async function collectProofSolverArtifactEvidence(
+  claimText,
+  options = {}
+) {
+  const adapters = normalizeAdapters(options.adapters);
+  const maxEvidenceWeight = normalizeMaxEvidenceWeight(
+    options.maxEvidenceWeight
+  );
+  const collected = await collectAdapterOutputs(claimText, options);
+  const rawArtifacts = [
+    ...normalizeArray(options.artifacts),
+    ...collected.artifacts,
+  ];
+  const diagnostics = [...collected.diagnostics];
+  const normalizedArtifacts = [];
+
+  for (const [index, raw] of rawArtifacts.entries()) {
+    const adapter = findAdapterForArtifact(raw, adapters);
+    if (!adapter) {
+      diagnostics.push({
+        id: `proof-solver-artifact-diagnostic-${index + 1}`,
+        level: 'warning',
+        message: `No proof/solver artifact adapter found for format "${cleanString(
+          raw?.format ?? raw?.artifact?.language
+        )}".`,
+      });
+      continue;
+    }
+    normalizedArtifacts.push(
+      adapter.adapt(raw, {
+        claimText,
+        index,
+        maxEvidenceWeight,
+        now: options.now,
+      })
+    );
+  }
+
+  const evidence = normalizedArtifacts.flatMap((artifact) =>
+    artifact.evidence ? [artifact.evidence] : []
+  );
+  return {
+    type: 'proof-solver-artifact-evidence',
+    version: 1,
+    status: evidence.length > 0 ? 'evidence-only' : 'empty',
+    claim: {
+      text: cleanString(claimText),
+      key: normalizeKey(claimText),
+    },
+    guardrails: {
+      executionGate: issue72Gate,
+      absoluteClaims: false,
+      defaultMaxEvidenceWeight,
+      reason: boundedEvidenceReason,
+    },
+    adapters: adapters.map(adapterSummary),
+    artifacts: normalizedArtifacts,
+    evidence,
+    diagnostics,
+  };
+}
+
+async function collectAdapterOutputs(claimText, options) {
+  const extractors = normalizeArray(options.sourceAdapters).filter(
+    (adapter) => typeof adapter?.extract === 'function'
+  );
+  const legacyExtractors = normalizeArray(options.adapters).filter(
+    (adapter) =>
+      typeof adapter?.extract === 'function' &&
+      typeof adapter?.adapt !== 'function'
+  );
+  const outputs = await Promise.all(
+    [...extractors, ...legacyExtractors].map((adapter) =>
+      invokeSourceAdapter(adapter, claimText, options)
+    )
+  );
+  return outputs.reduce(
+    (collected, output) => {
+      collected.artifacts.push(...expandArtifactOutput(output));
+      collected.diagnostics.push(...expandOutputDiagnostics(output));
+      return collected;
+    },
+    { artifacts: [], diagnostics: [] }
+  );
+}
+
+async function invokeSourceAdapter(adapter, claimText, options) {
+  try {
+    return await adapter.extract(claimText, {
+      now: options.now,
+      executionGate: issue72Gate,
+    });
+  } catch (error) {
+    return {
+      diagnostics: [
+        {
+          level: 'error',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
+  }
+}
+
+function expandArtifactOutput(output) {
+  if (Array.isArray(output)) {
+    return output.flatMap((entry) => expandArtifactOutput(entry));
+  }
+  if (
+    output?.type === 'proof-solver-artifact-evidence' &&
+    Array.isArray(output.artifacts)
+  ) {
+    return output.artifacts;
+  }
+  if (output?.artifacts) {
+    return normalizeArray(output.artifacts);
+  }
+  if (output?.diagnostics && !isArtifactLike(output)) {
+    return [];
+  }
+  return normalizeArray(output);
+}
+
+function expandOutputDiagnostics(output) {
+  if (Array.isArray(output)) {
+    return output.flatMap((entry) => expandOutputDiagnostics(entry));
+  }
+  return normalizeArray(output?.diagnostics).map((diagnostic, index) => ({
+    id:
+      cleanString(diagnostic?.id) ||
+      `proof-solver-source-adapter-diagnostic-${index + 1}`,
+    level: cleanString(diagnostic?.level) || 'warning',
+    message:
+      cleanString(diagnostic?.message) ||
+      'Source adapter returned a diagnostic.',
+  }));
+}
+
+function isArtifactLike(output) {
+  return Boolean(
+    output &&
+    (output.format ||
+      output.artifact ||
+      output.text ||
+      output.snippet ||
+      output.result ||
+      output.claim)
+  );
+}
+
+function normalizeAdapters(adapters) {
+  const provided = normalizeArray(adapters).filter(
+    (adapter) => typeof adapter?.adapt === 'function'
+  );
+  if (provided.length > 0) {
+    return provided;
+  }
+  return [
+    createLeanProofArtifactAdapter(),
+    createSmtLibSolverArtifactAdapter(),
+  ];
+}
+
+function findAdapterForArtifact(raw, adapters) {
+  const format = normalizeFormat(raw?.format ?? raw?.artifact?.language);
+  return adapters.find((adapter) =>
+    normalizeArray(adapter.formats).map(normalizeFormat).includes(format)
+  );
+}
+
+function normalizeArtifact(raw, context, defaults) {
+  const adapter = defaults.adapter;
+  const maxEvidenceWeight = normalizeMaxEvidenceWeight(
+    context.maxEvidenceWeight
+  );
+  const checks = defaults.checks;
+  const identity = artifactIdentity(raw, context, adapter);
+  const format = normalizeArtifactFormat(raw, defaults);
+  const result = normalizeArtifactResult(raw, identity.retrievedAt, defaults);
+  const eligible = isEvidenceEligible(identity.claimText, result, checks);
+  const status = eligible
+    ? PROOF_SOLVER_ARTIFACT_STATUS.VALIDATED
+    : PROOF_SOLVER_ARTIFACT_STATUS.CANDIDATE;
+  const weight = clamp(
+    finiteNumber(raw?.weight ?? raw?.result?.weight) ?? maxEvidenceWeight,
+    0,
+    maxEvidenceWeight
+  );
+  const normalized = {
+    id: identity.id,
+    family: defaults.family,
+    format,
+    system: artifactSystem(raw, adapter),
+    adapterId: adapter.id,
+    claim: {
+      text: identity.claimText,
+      key: normalizeKey(identity.claimText),
+    },
+    artifact: normalizeArtifactPayload(raw, defaults),
+    result,
+    provenance: {
+      sourceType: adapter.sourceType,
+      method: adapter.kind,
+      adapterId: adapter.id,
+      adapterVersion: adapter.version ?? null,
+      sourceUrl: identity.sourceUrl,
+      retrievedAt: identity.retrievedAt,
+    },
+    verification: {
+      executed: false,
+      executionGate: issue72Gate,
+      checks,
+      diagnostics: checks
+        .filter((check) => !check.passed)
+        .map((check) => ({
+          level: 'warning',
+          message: check.message,
+        })),
+    },
+    status,
+    truthScoring: truthScoring(status, eligible, maxEvidenceWeight),
+    evidence: null,
+  };
+
+  if (eligible) {
+    normalized.evidence = artifactToEvidence(normalized, { weight });
+  }
+  return normalized;
+}
+
+function artifactIdentity(raw, context, adapter) {
+  const claimText = cleanString(raw?.claim) || cleanString(context.claimText);
+  return {
+    id: artifactId(raw, context, adapter, claimText),
+    claimText,
+    sourceUrl: artifactSourceUrl(raw),
+    retrievedAt: artifactRetrievedAt(raw, context),
+  };
+}
+
+function artifactId(raw, context, adapter, claimText) {
+  return (
+    cleanString(raw?.id) ||
+    `${adapter.id}-${context.index + 1 || safeReference(claimText)}`
+  );
+}
+
+function artifactSourceUrl(raw) {
+  return (
+    cleanString(raw?.sourceUrl ?? raw?.result?.sourceUrl) ||
+    defaultSourceUrl(raw)
+  );
+}
+
+function artifactRetrievedAt(raw, context) {
+  return (
+    cleanString(raw?.retrievedAt ?? raw?.result?.checkedAt) ||
+    timestampFrom(context.now?.())
+  );
+}
+
+function normalizeArtifactFormat(raw, defaults) {
+  return (
+    normalizeFormat(raw?.format ?? raw?.artifact?.language) ||
+    defaults.defaultFormat
+  );
+}
+
+function normalizeArtifactPayload(raw, defaults) {
+  const artifact = raw?.artifact ?? {};
+  return {
+    language: cleanString(artifact.language) || defaults.defaultFormat,
+    entrypoint: cleanString(artifact.entrypoint) || null,
+    intent: cleanString(artifact.intent) || null,
+    text: cleanString(artifact.text ?? raw?.text ?? raw?.snippet),
+  };
+}
+
+function normalizeArtifactResult(raw, retrievedAt, defaults) {
+  const result = raw?.result ?? {};
+  return {
+    kind: defaults.resultKind,
+    outcome: normalizeOutcome(result.outcome ?? raw?.outcome),
+    polarity: normalizePolarity(raw?.polarity ?? result.polarity),
+    checker: cleanString(result.checker ?? result.solver) || null,
+    mode: cleanString(result.mode) || 'external',
+    checkedAt: cleanString(result.checkedAt) || retrievedAt,
+    absolute: false,
+  };
+}
+
+function artifactSystem(raw, adapter) {
+  const result = raw?.result ?? {};
+  return (
+    cleanString(raw?.system ?? result.checker ?? result.solver) || adapter.name
+  );
+}
+
+function isEvidenceEligible(claimText, result, checks) {
+  return Boolean(
+    claimText &&
+    result.outcome &&
+    result.polarity &&
+    checks.every((check) => check.passed)
+  );
+}
+
+function validateLeanArtifact(raw) {
+  const text = cleanString(raw?.artifact?.text ?? raw?.text ?? raw?.snippet);
+  return [
+    {
+      id: 'lean-non-empty',
+      passed: text.length > 0,
+      message: 'Lean artifact text is required.',
+    },
+    {
+      id: 'lean-declaration',
+      passed: /\b(theorem|lemma|example)\b/u.test(text),
+      message: 'Lean artifact should contain a theorem, lemma, or example.',
+    },
+    {
+      id: 'lean-proof-term',
+      passed: /:=/u.test(text),
+      message: 'Lean artifact should include a proof term separator.',
+    },
+  ];
+}
+
+function validateSmtLibArtifact(raw) {
+  const text = cleanString(raw?.artifact?.text ?? raw?.text ?? raw?.snippet);
+  const outcome = normalizeOutcome(raw?.result?.outcome ?? raw?.outcome);
+  return [
+    {
+      id: 'smt-lib-non-empty',
+      passed: text.length > 0,
+      message: 'SMT-LIB artifact text is required.',
+    },
+    {
+      id: 'smt-lib-check-sat',
+      passed: /\(\s*check-sat\s*\)/iu.test(text),
+      message: 'SMT-LIB artifact should contain a check-sat query.',
+    },
+    {
+      id: 'smt-lib-outcome',
+      passed: ['sat', 'unsat', 'unknown'].includes(outcome),
+      message: 'SMT-LIB result should be sat, unsat, or unknown.',
+    },
+  ];
+}
+
+function truthScoring(
+  status,
+  included,
+  maxEvidenceWeight = defaultMaxEvidenceWeight
+) {
+  return {
+    included,
+    eligible: status === PROOF_SOLVER_ARTIFACT_STATUS.VALIDATED,
+    absolute: false,
+    maxEvidenceWeight,
+    executionGate: issue72Gate,
+    reason: included
+      ? boundedEvidenceReason
+      : 'Artifact is retained as provenance, but it is not scored until it names a claim, result, polarity, and passes adapter shape checks.',
+  };
+}
+
+function artifactToEvidence(artifact, options) {
+  const claimKey = artifact.claim.key;
+  return {
+    id: `artifact-evidence-${safeReference(artifact.id)}`,
+    key: claimKey,
+    polarity: artifact.result.polarity,
+    weight: options.weight,
+    sourceType: artifact.provenance.sourceType,
+    situation: artifactSituation,
+    sourceUrl: artifact.provenance.sourceUrl,
+    retrievedAt: artifact.provenance.retrievedAt,
+    claim: artifactEvidenceClaim(artifact),
+    identifiers: {
+      artifactId: artifact.id,
+      format: artifact.format,
+      family: artifact.family,
+      system: artifact.system,
+      outcome: artifact.result.outcome,
+      executionGate: 'issue-72',
+    },
+    context: {
+      artifact: {
+        id: artifact.id,
+        format: artifact.format,
+        family: artifact.family,
+        result: artifact.result,
+        verification: artifact.verification,
+      },
+      reasoningSteps: [
+        {
+          text: `${artifact.system} artifact reported ${artifact.result.outcome} for "${artifact.claim.text}".`,
+          sourceUrl: artifact.provenance.sourceUrl,
+        },
+        {
+          text: 'meta-expression records this as bounded evidence and does not execute the external checker in this adapter.',
+          sourceUrl: issue72Gate.url,
+        },
+      ],
+    },
+  };
+}
+
+function artifactEvidenceClaim(artifact) {
+  const outcome = artifact.result.outcome;
+  const system = artifact.system;
+  const family =
+    artifact.family === 'proof-assistant'
+      ? 'proof artifact'
+      : 'solver artifact';
+  return `${system} ${family} reports ${outcome} for "${artifact.claim.text}"; recorded as bounded external evidence, not an absolute local proof.`;
+}
+
+function adapterSummary(adapter) {
+  return {
+    id: adapter.id,
+    name: adapter.name,
+    kind: adapter.kind,
+    formats: normalizeArray(adapter.formats),
+    sourceType: adapter.sourceType,
+    version: adapter.version ?? null,
+  };
+}
+
+function defaultSourceUrl(raw) {
+  const system = cleanString(raw?.system).toLowerCase();
+  if (system.includes('lean')) {
+    return 'https://lean-lang.org/';
+  }
+  if (system.includes('z3')) {
+    return 'https://github.com/Z3Prover/z3';
+  }
+  return null;
+}
+
+function normalizeOutcome(value) {
+  const normalized = cleanString(value).toLowerCase();
+  if (normalized === 'proved' || normalized === 'valid') {
+    return normalized;
+  }
+  if (['sat', 'unsat', 'unknown', 'counterexample'].includes(normalized)) {
+    return normalized;
+  }
+  return normalized || null;
+}
+
+function normalizePolarity(value) {
+  const normalized = cleanString(value).toLowerCase();
+  if (normalized === 'supports') {
+    return 'support';
+  }
+  if (normalized === 'refutes') {
+    return 'refute';
+  }
+  if (normalized === 'support' || normalized === 'refute') {
+    return normalized;
+  }
+  return null;
+}
+
+function normalizeFormat(value) {
+  const normalized = cleanString(value).toLowerCase();
+  if (normalized === 'smtlib' || normalized === 'smt2') {
+    return PROOF_SOLVER_ARTIFACT_FORMATS.SMT_LIB;
+  }
+  if (normalized === 'lean') {
+    return PROOF_SOLVER_ARTIFACT_FORMATS.LEAN4;
+  }
+  return normalized;
+}
+
+function normalizeKey(input) {
+  return cleanString(input)
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/gu, ' ');
+}
+
+function normalizeArray(value) {
+  if (Array.isArray(value)) {
+    return value.filter((entry) => entry !== null && entry !== undefined);
+  }
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return [value];
+}
+
+function cleanString(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function finiteNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeMaxEvidenceWeight(value) {
+  const parsed = finiteNumber(value);
+  return parsed === null ? defaultMaxEvidenceWeight : clamp(parsed, 0, 0.99);
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function timestampFrom(value) {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toISOString();
+}
+
+function safeReference(value) {
+  return cleanString(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-|-$/gu, '')
+    .slice(0, 64);
+}

--- a/js/tests/fixtures/issue-93/proof-solver-artifacts.json
+++ b/js/tests/fixtures/issue-93/proof-solver-artifacts.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "lean4-one-plus-one-proof",
+    "format": "lean4",
+    "system": "Lean 4",
+    "claim": "1 + 1 = 2",
+    "polarity": "support",
+    "sourceUrl": "https://lean-lang.org/",
+    "retrievedAt": "2026-05-26",
+    "artifact": {
+      "language": "lean4",
+      "entrypoint": "example",
+      "text": "example : 1 + 1 = 2 := rfl\n"
+    },
+    "result": {
+      "outcome": "proved",
+      "checker": "Lean 4",
+      "mode": "fixture",
+      "checkedAt": "2026-05-26"
+    }
+  },
+  {
+    "id": "smt-lib-one-plus-one-unsat",
+    "format": "smt-lib",
+    "system": "Z3",
+    "claim": "1 + 1 = 2",
+    "polarity": "support",
+    "sourceUrl": "https://github.com/Z3Prover/z3",
+    "retrievedAt": "2026-05-26",
+    "artifact": {
+      "language": "smt-lib",
+      "intent": "refute-negation",
+      "text": "(set-logic QF_LIA)\n(assert (not (= (+ 1 1) 2)))\n(check-sat)\n"
+    },
+    "result": {
+      "outcome": "unsat",
+      "solver": "Z3",
+      "mode": "fixture",
+      "checkedAt": "2026-05-26"
+    }
+  }
+]

--- a/js/tests/integration/issue-93-proof-solver-artifacts.test.js
+++ b/js/tests/integration/issue-93-proof-solver-artifacts.test.js
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'test-anywhere';
+import {
+  analyzeStatement,
+  collectProofSolverArtifactEvidence,
+  createLeanProofArtifactAdapter,
+  createSmtLibSolverArtifactAdapter,
+} from '../../src/index.js';
+
+const artifacts = JSON.parse(
+  readFileSync(
+    new URL(
+      '../fixtures/issue-93/proof-solver-artifacts.json',
+      import.meta.url
+    ),
+    'utf8'
+  )
+);
+
+describe('issue 93 - proof and solver artifact adapters', () => {
+  it('normalizes proof assistant and solver artifacts into bounded provenance-bearing evidence', async () => {
+    const bundle = await collectProofSolverArtifactEvidence('1 + 1 = 2', {
+      artifacts,
+      adapters: [
+        createLeanProofArtifactAdapter(),
+        createSmtLibSolverArtifactAdapter(),
+      ],
+      maxEvidenceWeight: 0.75,
+      now: () => new Date('2026-05-26T12:00:00.000Z'),
+    });
+
+    expect(bundle.type).toBe('proof-solver-artifact-evidence');
+    expect(bundle.status).toBe('evidence-only');
+    expect(bundle.guardrails.executionGate.issue).toBe(72);
+    expect(bundle.guardrails.absoluteClaims).toBe(false);
+    expect(bundle.artifacts.map((artifact) => artifact.format)).toEqual([
+      'lean4',
+      'smt-lib',
+    ]);
+    expect(bundle.artifacts[0].family).toBe('proof-assistant');
+    expect(bundle.artifacts[1].family).toBe('solver-query');
+    expect(
+      bundle.artifacts.every((artifact) => artifact.truthScoring.included)
+    ).toBe(true);
+    expect(
+      bundle.artifacts.every((artifact) => !artifact.truthScoring.absolute)
+    ).toBe(true);
+    expect(bundle.evidence.length).toBe(2);
+    expect(bundle.evidence.map((evidence) => evidence.sourceType)).toEqual([
+      'proof-assistant-artifact',
+      'solver-artifact',
+    ]);
+    expect(bundle.evidence.every((evidence) => evidence.weight < 1)).toBe(true);
+    expect(bundle.evidence.every((evidence) => evidence.weight <= 0.75)).toBe(
+      true
+    );
+    expect(
+      bundle.artifacts.every(
+        (artifact) => artifact.truthScoring.maxEvidenceWeight === 0.75
+      )
+    ).toBe(true);
+    expect(bundle.evidence[0].claim).toContain('Lean 4');
+    expect(bundle.evidence[1].claim).toContain('unsat');
+  });
+
+  it('attaches artifact evidence through analyzeStatement without producing absolute confidence', async () => {
+    const bundle = await collectProofSolverArtifactEvidence('1 + 1 = 2', {
+      artifacts,
+    });
+    const analysis = analyzeStatement('1 + 1 = 2', {
+      interpretationIndex: 1,
+      evidence: bundle.evidence,
+    });
+    const artifactEvidenceLinks = analysis.linksNetwork.links.filter(
+      (link) =>
+        link.role === 'evidence' &&
+        link.value.situation === 'external-proof-solver-artifact'
+    );
+
+    expect(analysis.result.kind).toBe('evidence-estimate');
+    expect(analysis.result.confidence).toBeLessThan(1);
+    expect(analysis.result.supportingEvidence.length).toBe(2);
+    expect(artifactEvidenceLinks.length).toBe(2);
+    expect(artifactEvidenceLinks[0].provenance.sourceType).toBe(
+      'proof-assistant-artifact'
+    );
+    expect(artifactEvidenceLinks[1].provenance.sourceType).toBe(
+      'solver-artifact'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #93

## Summary
- Adds Lean 4 proof and SMT-LIB solver artifact adapters that normalize external artifacts into a shared `proof-solver-artifact-evidence` bundle.
- Emits provenance-bearing evidence for `analyzeStatement(..., { evidence })` while keeping artifact execution and parity validation behind issue #72.
- Adds issue #93 fixtures, documentation, TypeScript declarations, and a changeset.

## Reproduce / Verify
- `node --test js/tests/integration/issue-93-proof-solver-artifacts.test.js`
- `npm run check`
- `npm test`
- `bun test --timeout 30000`
- `bash scripts/check-file-line-limits.sh`
- `bash scripts/check-mjs-syntax.sh`
- `node scripts/check-version.mjs`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
- `npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"`
- `npm run test:wasm`