### PR TITLE
Add browser/editor writing-assistant surface

### DIFF
--- a/.changeset/issue-94-writing-assistant-surface.md
+++ b/.changeset/issue-94-writing-assistant-surface.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': patch
+---
+
+Add a browser/editor writing-assistant surface that delegates to the existing analyze, check, formalize, translate, and uniqueness APIs while preserving embedded Links Notation and report exports.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
 # Updated: 2026-05-26T06:39:16.671Z
 # Updated: 2026-05-26T06:58:24.996Z
-# Updated: 2026-05-26T07:48:01.197Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-26T05:48:32.889Z for PR creation at branch issue-89-4d53f5773d5a for issue https://github.com/link-assistant/meta-expression/issues/89
 # Updated: 2026-05-26T06:39:16.671Z
 # Updated: 2026-05-26T06:58:24.996Z
+# Updated: 2026-05-26T07:48:01.197Z

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Core exports:
   public web and scholarly APIs, returning existing-likelihood scores,
   citation/rewording suggestions, source matches, HTML, Markdown, and Links
   Notation.
+- `createWritingAssistantSurface(options)` exposes a browser/editor integration
+  wrapper over `analyze`, `check`, `formalize`, `translate`, and `uniqueness`
+  without replacing the core APIs. Candidate suggestions are explicit, and
+  evidence-backed checks are marked separately from style rewrites.
 - `exportPortableCaseData(input)`, `importPortableCaseData(input)`,
   `savePortableCaseToDoublets(input)`, and `loadPortableCaseFromDoublets(input)`
   preserve analysis/link-network cases as portable Doublets-backed data with

--- a/docs/case-studies/issue-94/README.md
+++ b/docs/case-studies/issue-94/README.md
@@ -1,0 +1,55 @@
+# Issue 94: Browser and Editor Writing Assistant Surfaces
+
+Issue: <https://github.com/link-assistant/meta-expression/issues/94>
+PR: <https://github.com/link-assistant/meta-expression/pull/106>
+
+## Summary
+
+Issue 94 adds a reusable writing-assistant integration surface for browser
+extensions, editor extensions, document add-ins, and other embedded clients.
+The surface is a thin wrapper around the existing library APIs:
+
+- `analyzeStatement()` / `analyzeStatementWithLiveEvidence()`
+- `checkText()` / `checkTextWithLiveEvidence()`
+- `formalizeTextWith()`
+- `translateTextWith()`
+- `searchTextUniqueness()`
+
+The wrapper returns a consistent operation envelope with the original result,
+Links Notation export, issue-report URLs where applicable, embedded context,
+capabilities, and guardrail metadata.
+
+## Guardrails
+
+The surface records the natural-language-first rules in
+`WRITING_ASSISTANT_GUARDRAILS`:
+
+- candidate interpretations and formalization links are explicit suggestions;
+- candidate suggestions require selection and are not truth evidence;
+- evidence-backed checks are marked as evidence checks;
+- evidence-backed checks are never style rewrites;
+- the core surface does not provide style rewrites by default.
+
+These flags let browser and editor hosts render checks, candidates, and future
+style rewrites as separate UI affordances.
+
+## Harness
+
+The regression harness lives in
+[`js/tests/integration/issue-94-writing-assistant-surface.test.js`](../../../js/tests/integration/issue-94-writing-assistant-surface.test.js).
+It uses
+[`js/tests/fixtures/issue-94/mock-extension-selection.json`](../../../js/tests/fixtures/issue-94/mock-extension-selection.json)
+to verify that an embedded selection can:
+
+- run all five operations through delegated APIs;
+- export Links Notation from the wrapper;
+- create prefilled report URLs from the embedded page context;
+- preserve candidate and evidence-check guardrail metadata.
+
+## Verification
+
+Focused regression:
+
+```bash
+node --test js/tests/integration/issue-94-writing-assistant-surface.test.js
+```

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -650,7 +650,7 @@ export interface WritingAssistantServices {
 }
 
 export interface WritingAssistantSurfaceOptions {
-  surface?: WritingAssistantSurfaceKind | string;
+  surface?: WritingAssistantSurfaceKind | string | WritingAssistantSurface;
   services?: WritingAssistantServices;
   context?: WritingAssistantContext;
   options?: Record<string, unknown>;

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -509,6 +509,225 @@ export interface IssueReportOptions {
   timestamp?: string;
 }
 
+export type WritingAssistantOperation =
+  | 'analyze'
+  | 'check'
+  | 'formalize'
+  | 'translate'
+  | 'uniqueness';
+
+export type WritingAssistantSurfaceKind =
+  | 'browser-extension'
+  | 'editor-extension'
+  | 'document-addin'
+  | 'embedded-writing-assistant';
+
+export interface WritingAssistantGuardrails {
+  naturalLanguageFirst: true;
+  candidateSuggestionsExplicit: true;
+  candidateSuggestionsRequireSelection: true;
+  candidateSuggestionsAreTruthEvidence: false;
+  evidenceChecksCarryEvidence: true;
+  evidenceChecksAreStyleRewrites: false;
+  styleRewritesProvidedByCore: false;
+}
+
+export interface WritingAssistantContext {
+  pageUrl?: string;
+  documentUrl?: string;
+  userAgent?: string;
+  selectionStart?: number;
+  selectionEnd?: number;
+  [key: string]: unknown;
+}
+
+export interface WritingAssistantRequest {
+  operation?: WritingAssistantOperation | string;
+  action?: WritingAssistantOperation | string;
+  text?: string;
+  input?: string;
+  surface?: WritingAssistantSurfaceKind | string;
+  context?: WritingAssistantContext;
+  report?: IssueReportOptions;
+  options?: Record<string, unknown>;
+  live?: boolean;
+  limit?: number;
+  from?: string;
+  to?: string;
+  sourceLanguage?: string;
+  targetLanguage?: string;
+}
+
+export interface WritingAssistantSuggestion {
+  id: string;
+  kind:
+    | 'candidate-interpretation'
+    | 'evidence-check'
+    | 'candidate-formalization-link'
+    | 'translation-question'
+    | 'originality-check'
+    | string;
+  category: 'candidate' | 'evidence-check' | string;
+  operation: WritingAssistantOperation;
+  text: string;
+  explicit: boolean;
+  evidenceBacked: boolean;
+  styleRewrite: boolean;
+  requiresUserSelection: boolean;
+  source?: string;
+  selected?: boolean;
+  candidate?: unknown;
+  evidence?: unknown[];
+  result?: unknown;
+  [key: string]: unknown;
+}
+
+export interface WritingAssistantExports {
+  linksNotation: string;
+  issueReportUrl?: string;
+  issueReportUrls?: Array<{ statementId: string; url: string }>;
+}
+
+export type WritingAssistantOperationPayload =
+  | StatementAnalysis
+  | CheckResult
+  | FormalizeResult
+  | TranslateResult
+  | UniquenessResult
+  | Record<string, unknown>;
+
+export interface WritingAssistantOperationResult {
+  kind: 'writing-assistant-operation-result';
+  operation: WritingAssistantOperation;
+  surface: WritingAssistantSurfaceKind;
+  status: string;
+  text: string;
+  context: WritingAssistantContext;
+  guardrails: WritingAssistantGuardrails;
+  suggestions: WritingAssistantSuggestion[];
+  exports: WritingAssistantExports;
+  result: WritingAssistantOperationPayload;
+}
+
+export interface WritingAssistantCapability {
+  operation: WritingAssistantOperation;
+  api: string;
+  exports: string[];
+  suggestionKinds: string[];
+}
+
+export interface WritingAssistantServices {
+  analyzeStatement?: (
+    input: string,
+    options?: AnalysisOptions
+  ) => StatementAnalysis;
+  analyzeStatementWithLiveEvidence?: (
+    input: string,
+    options?: AnalysisOptions
+  ) => Promise<StatementAnalysis>;
+  checkText?: (input: string, options?: Record<string, unknown>) => CheckResult;
+  checkTextWithLiveEvidence?: (
+    input: string,
+    options?: Record<string, unknown>
+  ) => Promise<CheckResult>;
+  formalizeTextWith?: (
+    input: string,
+    options?: FormalizeOptions
+  ) => Promise<FormalizeResult>;
+  translateTextWith?: (
+    input: string,
+    options?: TranslateOptions
+  ) => Promise<TranslateResult>;
+  searchTextUniqueness?: (
+    input: string,
+    options?: UniquenessOptions
+  ) => Promise<UniquenessResult>;
+  createIssueReportUrl?: (
+    analysis: StatementAnalysis,
+    options?: IssueReportOptions
+  ) => string;
+  serializeLinksNotation?: (linksNetwork: LinksNetwork) => string;
+}
+
+export interface WritingAssistantSurfaceOptions {
+  surface?: WritingAssistantSurfaceKind | string;
+  services?: WritingAssistantServices;
+  context?: WritingAssistantContext;
+  options?: Record<string, unknown>;
+  operationOptions?: Partial<
+    Record<WritingAssistantOperation, Record<string, unknown>>
+  >;
+  fetch?: typeof fetch | null;
+  cache?: Map<string, unknown>;
+  now?: () => number | Date | string;
+  live?: boolean;
+  labels?: string;
+  repoUrl?: string;
+  userAgent?: string;
+}
+
+export interface WritingAssistantSurface {
+  kind: 'writing-assistant-surface';
+  surface: WritingAssistantSurfaceKind;
+  guardrails: WritingAssistantGuardrails;
+  capabilities: WritingAssistantCapability[];
+  run(
+    request: WritingAssistantRequest
+  ): Promise<WritingAssistantOperationResult>;
+  analyze(
+    text: string,
+    request?: Omit<WritingAssistantRequest, 'operation' | 'text'>
+  ): Promise<WritingAssistantOperationResult>;
+  check(
+    text: string,
+    request?: Omit<WritingAssistantRequest, 'operation' | 'text'>
+  ): Promise<WritingAssistantOperationResult>;
+  formalize(
+    text: string,
+    request?: Omit<WritingAssistantRequest, 'operation' | 'text'>
+  ): Promise<WritingAssistantOperationResult>;
+  translate(
+    text: string,
+    request?: Omit<WritingAssistantRequest, 'operation' | 'text'>
+  ): Promise<WritingAssistantOperationResult>;
+  uniqueness(
+    text: string,
+    request?: Omit<WritingAssistantRequest, 'operation' | 'text'>
+  ): Promise<WritingAssistantOperationResult>;
+}
+
+export interface MockWritingAssistantSelection extends WritingAssistantContext {
+  text: string;
+}
+
+export interface WritingAssistantEmbeddedExportVerification {
+  ok: boolean;
+  linksNotation: boolean;
+  issueReportUrl: boolean;
+  issueReportUrls: Array<{ statementId: string; url: string }>;
+  errors: string[];
+}
+
+export interface MockWritingAssistantExtensionHarness {
+  kind: 'mock-writing-assistant-extension-harness';
+  surface: WritingAssistantSurfaceKind;
+  guardrails: WritingAssistantGuardrails;
+  createSelection(
+    text: string,
+    context?: WritingAssistantContext
+  ): MockWritingAssistantSelection;
+  runSelection(
+    operation: WritingAssistantOperation | string,
+    selection: MockWritingAssistantSelection | string,
+    request?: Omit<WritingAssistantRequest, 'operation' | 'text'>
+  ): Promise<WritingAssistantOperationResult>;
+  verifySelectionExports(
+    operation: WritingAssistantOperation | string,
+    selection: MockWritingAssistantSelection | string,
+    request?: Omit<WritingAssistantRequest, 'operation' | 'text'>
+  ): Promise<WritingAssistantEmbeddedExportVerification>;
+}
+
 export interface WikimediaEvidenceClient {
   cache: Map<string, unknown>;
   resolveEvidence(
@@ -707,6 +926,42 @@ export declare function createIssueReportUrl(
   analysis: StatementAnalysis,
   options?: IssueReportOptions
 ): string;
+
+export declare const WRITING_ASSISTANT_OPERATIONS: {
+  readonly ANALYZE: 'analyze';
+  readonly CHECK: 'check';
+  readonly FORMALIZE: 'formalize';
+  readonly TRANSLATE: 'translate';
+  readonly UNIQUENESS: 'uniqueness';
+};
+
+export declare const WRITING_ASSISTANT_SURFACES: {
+  readonly BROWSER_EXTENSION: 'browser-extension';
+  readonly EDITOR_EXTENSION: 'editor-extension';
+  readonly DOCUMENT_ADDIN: 'document-addin';
+  readonly EMBEDDED: 'embedded-writing-assistant';
+};
+
+export declare const WRITING_ASSISTANT_GUARDRAILS: WritingAssistantGuardrails;
+
+export declare function listWritingAssistantCapabilities(): WritingAssistantCapability[];
+
+export declare function createWritingAssistantSurface(
+  options?: WritingAssistantSurfaceOptions
+): WritingAssistantSurface;
+
+export declare function runWritingAssistantOperation(
+  request: WritingAssistantRequest,
+  options?: WritingAssistantSurfaceOptions
+): Promise<WritingAssistantOperationResult>;
+
+export declare function createMockWritingAssistantExtensionHarness(
+  options?: WritingAssistantSurfaceOptions
+): MockWritingAssistantExtensionHarness;
+
+export declare function verifyWritingAssistantEmbeddedExports(
+  result: WritingAssistantOperationResult
+): WritingAssistantEmbeddedExportVerification;
 
 export declare function computeEvidenceConfidence(
   evidenceItems: EvidenceItem[]

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -184,6 +184,16 @@ export {
   createSmtLibSolverArtifactAdapter,
 } from './proof-solver-artifacts.js';
 export {
+  WRITING_ASSISTANT_GUARDRAILS,
+  WRITING_ASSISTANT_OPERATIONS,
+  WRITING_ASSISTANT_SURFACES,
+  createMockWritingAssistantExtensionHarness,
+  createWritingAssistantSurface,
+  listWritingAssistantCapabilities,
+  runWritingAssistantOperation,
+  verifyWritingAssistantEmbeddedExports,
+} from './writing-assistant.js';
+export {
   createDefaultPreferenceProfile,
   createPreferenceEvidence,
   getPreferenceEvidenceSituationProbability,

--- a/js/src/writing-assistant.js
+++ b/js/src/writing-assistant.js
@@ -1,0 +1,578 @@
+import { analyzeStatement, analyzeStatementWithLiveEvidence } from './index.js';
+import { checkText, checkTextWithLiveEvidence } from './check.js';
+import { formalizeTextWith } from './formalize.js';
+import { createIssueReportUrl, serializeLinksNotation } from './reporting.js';
+import { translateTextWith } from './translate.js';
+import { searchTextUniqueness } from './uniqueness.js';
+
+export const WRITING_ASSISTANT_OPERATIONS = Object.freeze({
+  ANALYZE: 'analyze',
+  CHECK: 'check',
+  FORMALIZE: 'formalize',
+  TRANSLATE: 'translate',
+  UNIQUENESS: 'uniqueness',
+});
+
+export const WRITING_ASSISTANT_SURFACES = Object.freeze({
+  BROWSER_EXTENSION: 'browser-extension',
+  EDITOR_EXTENSION: 'editor-extension',
+  DOCUMENT_ADDIN: 'document-addin',
+  EMBEDDED: 'embedded-writing-assistant',
+});
+
+export const WRITING_ASSISTANT_GUARDRAILS = Object.freeze({
+  naturalLanguageFirst: true,
+  candidateSuggestionsExplicit: true,
+  candidateSuggestionsRequireSelection: true,
+  candidateSuggestionsAreTruthEvidence: false,
+  evidenceChecksCarryEvidence: true,
+  evidenceChecksAreStyleRewrites: false,
+  styleRewritesProvidedByCore: false,
+});
+
+const operationAliases = new Map([
+  ['analysis', WRITING_ASSISTANT_OPERATIONS.ANALYZE],
+  ['fact-check', WRITING_ASSISTANT_OPERATIONS.CHECK],
+  ['factcheck', WRITING_ASSISTANT_OPERATIONS.CHECK],
+  ['originality', WRITING_ASSISTANT_OPERATIONS.UNIQUENESS],
+  ['originality-check', WRITING_ASSISTANT_OPERATIONS.UNIQUENESS],
+  ['uniquness', WRITING_ASSISTANT_OPERATIONS.UNIQUENESS],
+]);
+
+const defaultServices = Object.freeze({
+  analyzeStatement,
+  analyzeStatementWithLiveEvidence,
+  checkText,
+  checkTextWithLiveEvidence,
+  formalizeTextWith,
+  translateTextWith,
+  searchTextUniqueness,
+  createIssueReportUrl,
+  serializeLinksNotation,
+});
+
+export function listWritingAssistantCapabilities() {
+  return [
+    {
+      operation: WRITING_ASSISTANT_OPERATIONS.ANALYZE,
+      api: 'analyzeStatement',
+      exports: ['linksNotation', 'issueReportUrl'],
+      suggestionKinds: ['candidate-interpretation'],
+    },
+    {
+      operation: WRITING_ASSISTANT_OPERATIONS.CHECK,
+      api: 'checkText',
+      exports: ['linksNotation', 'issueReportUrl', 'issueReportUrls'],
+      suggestionKinds: ['evidence-check'],
+    },
+    {
+      operation: WRITING_ASSISTANT_OPERATIONS.FORMALIZE,
+      api: 'formalizeTextWith',
+      exports: ['linksNotation'],
+      suggestionKinds: ['candidate-formalization-link'],
+    },
+    {
+      operation: WRITING_ASSISTANT_OPERATIONS.TRANSLATE,
+      api: 'translateTextWith',
+      exports: ['linksNotation'],
+      suggestionKinds: ['translation-question'],
+    },
+    {
+      operation: WRITING_ASSISTANT_OPERATIONS.UNIQUENESS,
+      api: 'searchTextUniqueness',
+      exports: ['linksNotation'],
+      suggestionKinds: ['originality-check'],
+    },
+  ];
+}
+
+export function createWritingAssistantSurface(options = {}) {
+  const surface = normalizeSurface(options.surface);
+  const baseOptions = {
+    ...options,
+    surface,
+    services: mergeServices(options.services),
+  };
+  const run = (request) => runWritingAssistantOperation(request, baseOptions);
+
+  return Object.freeze({
+    kind: 'writing-assistant-surface',
+    surface,
+    guardrails: WRITING_ASSISTANT_GUARDRAILS,
+    capabilities: listWritingAssistantCapabilities(),
+    run,
+    analyze: (text, request = {}) =>
+      run({
+        ...request,
+        operation: WRITING_ASSISTANT_OPERATIONS.ANALYZE,
+        text,
+      }),
+    check: (text, request = {}) =>
+      run({ ...request, operation: WRITING_ASSISTANT_OPERATIONS.CHECK, text }),
+    formalize: (text, request = {}) =>
+      run({
+        ...request,
+        operation: WRITING_ASSISTANT_OPERATIONS.FORMALIZE,
+        text,
+      }),
+    translate: (text, request = {}) =>
+      run({
+        ...request,
+        operation: WRITING_ASSISTANT_OPERATIONS.TRANSLATE,
+        text,
+      }),
+    uniqueness: (text, request = {}) =>
+      run({
+        ...request,
+        operation: WRITING_ASSISTANT_OPERATIONS.UNIQUENESS,
+        text,
+      }),
+  });
+}
+
+export async function runWritingAssistantOperation(request, options = {}) {
+  const normalizedRequest = isObject(request) ? request : {};
+  const operation = operationFromRequest(normalizedRequest);
+  const text = textFromRequest(normalizedRequest);
+  const context = contextFromRequest(normalizedRequest, options);
+  const services = mergeServices(options.services);
+  const operationOptions = collectOperationOptions(
+    operation,
+    normalizedRequest,
+    options
+  );
+  const reportOptions = collectReportOptions(
+    normalizedRequest,
+    options,
+    context
+  );
+  const result = await callOperation(
+    operation,
+    text,
+    operationOptions,
+    services
+  );
+
+  return {
+    kind: 'writing-assistant-operation-result',
+    operation,
+    surface: normalizeSurface(normalizedRequest.surface ?? options.surface),
+    status: result?.status ?? 'completed',
+    text,
+    context,
+    guardrails: WRITING_ASSISTANT_GUARDRAILS,
+    suggestions: collectSuggestions(operation, result),
+    exports: collectExports(operation, result, services, reportOptions),
+    result,
+  };
+}
+
+export function createMockWritingAssistantExtensionHarness(options = {}) {
+  const assistantSurface =
+    isObject(options.surface) && typeof options.surface.run === 'function'
+      ? options.surface
+      : createWritingAssistantSurface(options);
+  const defaultContext = normalizeContext(options.context);
+
+  return Object.freeze({
+    kind: 'mock-writing-assistant-extension-harness',
+    surface: assistantSurface.surface,
+    guardrails: assistantSurface.guardrails,
+    createSelection(text, context = {}) {
+      return {
+        text: String(text ?? ''),
+        ...defaultContext,
+        ...normalizeContext(context),
+      };
+    },
+    runSelection(operation, selection, request = {}) {
+      const selectedText =
+        typeof selection === 'string'
+          ? selection
+          : String(selection?.text ?? request.text ?? '');
+      const selectionContext =
+        typeof selection === 'string' ? {} : normalizeContext(selection);
+      const context = {
+        ...defaultContext,
+        ...selectionContext,
+        ...normalizeContext(request.context),
+      };
+      return assistantSurface.run({
+        ...request,
+        operation,
+        text: selectedText,
+        context,
+      });
+    },
+    async verifySelectionExports(operation, selection, request = {}) {
+      const result = await this.runSelection(operation, selection, request);
+      return verifyWritingAssistantEmbeddedExports(result);
+    },
+  });
+}
+
+export function verifyWritingAssistantEmbeddedExports(result) {
+  const issueReportUrls = Array.isArray(result?.exports?.issueReportUrls)
+    ? result.exports.issueReportUrls
+    : [];
+  const hasIssueReportUrl =
+    typeof result?.exports?.issueReportUrl === 'string' &&
+    result.exports.issueReportUrl.includes('/issues/new?');
+  const hasLinksNotation =
+    typeof result?.exports?.linksNotation === 'string' &&
+    result.exports.linksNotation.trim().length > 0;
+  const errors = [];
+
+  if (!hasLinksNotation) {
+    errors.push('Missing Links Notation export.');
+  }
+  if (
+    [
+      WRITING_ASSISTANT_OPERATIONS.ANALYZE,
+      WRITING_ASSISTANT_OPERATIONS.CHECK,
+    ].includes(result?.operation) &&
+    !hasIssueReportUrl &&
+    issueReportUrls.length === 0
+  ) {
+    errors.push('Missing prefilled issue report URL.');
+  }
+
+  return {
+    ok: errors.length === 0,
+    linksNotation: hasLinksNotation,
+    issueReportUrl: hasIssueReportUrl,
+    issueReportUrls,
+    errors,
+  };
+}
+
+function callOperation(operation, text, options, services) {
+  switch (operation) {
+    case WRITING_ASSISTANT_OPERATIONS.ANALYZE:
+      return options.live === true
+        ? services.analyzeStatementWithLiveEvidence(text, options)
+        : services.analyzeStatement(text, options);
+    case WRITING_ASSISTANT_OPERATIONS.CHECK:
+      return options.live === true
+        ? services.checkTextWithLiveEvidence(text, options)
+        : services.checkText(text, options);
+    case WRITING_ASSISTANT_OPERATIONS.FORMALIZE:
+      return services.formalizeTextWith(text, options);
+    case WRITING_ASSISTANT_OPERATIONS.TRANSLATE:
+      return services.translateTextWith(text, options);
+    case WRITING_ASSISTANT_OPERATIONS.UNIQUENESS:
+      return services.searchTextUniqueness(text, options);
+    default:
+      throw new Error(`Unsupported writing-assistant operation: ${operation}`);
+  }
+}
+
+function collectSuggestions(operation, result) {
+  switch (operation) {
+    case WRITING_ASSISTANT_OPERATIONS.ANALYZE:
+      return collectInterpretationSuggestions(result, operation);
+    case WRITING_ASSISTANT_OPERATIONS.CHECK:
+      return collectEvidenceCheckSuggestions(result, operation);
+    case WRITING_ASSISTANT_OPERATIONS.FORMALIZE:
+      return collectFormalizeSuggestions(result, operation);
+    case WRITING_ASSISTANT_OPERATIONS.TRANSLATE:
+      return collectTranslateSuggestions(result, operation);
+    case WRITING_ASSISTANT_OPERATIONS.UNIQUENESS:
+      return collectUniquenessSuggestions(result, operation);
+    default:
+      return [];
+  }
+}
+
+function collectInterpretationSuggestions(analysis, operation) {
+  return (analysis?.interpretations ?? []).map((interpretation, index) =>
+    suggestion({
+      id: interpretation.id ?? `candidate-interpretation-${index + 1}`,
+      kind: 'candidate-interpretation',
+      category: 'candidate',
+      operation,
+      text: interpretation.paraphrase ?? '',
+      source: 'analyzeStatement.interpretations',
+      requiresUserSelection: true,
+      selected: interpretation.id === analysis?.selectedInterpretation?.id,
+      candidate: {
+        id: interpretation.id ?? null,
+        kind: interpretation.kind ?? null,
+        confidence: interpretation.confidence ?? null,
+        formalizationLevel: interpretation.formalizationLevel ?? null,
+      },
+    })
+  );
+}
+
+function collectEvidenceCheckSuggestions(result, operation) {
+  return (result?.statements ?? []).map((statement, index) =>
+    suggestion({
+      id: `${statement.id ?? `statement-${index + 1}`}-evidence-check`,
+      kind: 'evidence-check',
+      category: 'evidence-check',
+      operation,
+      text: statement.text ?? '',
+      source: 'checkText.statements',
+      evidenceBacked: true,
+      result: {
+        value: statement.result?.value ?? null,
+        confidence: statement.result?.confidence ?? null,
+        correctness: statement.correctness ?? null,
+        explanation: statement.result?.explanation ?? '',
+      },
+      evidence: (statement.result?.calculation?.evidence ?? []).slice(0, 3),
+    })
+  );
+}
+
+function collectFormalizeSuggestions(result, operation) {
+  const suggestions = [];
+  for (const [phraseIndex, phrase] of (result?.phrases ?? []).entries()) {
+    for (const [candidateIndex, candidate] of (
+      phrase.candidates ?? []
+    ).entries()) {
+      suggestions.push(
+        suggestion({
+          id: `formalize-${phraseIndex + 1}-candidate-${candidateIndex + 1}`,
+          kind: 'candidate-formalization-link',
+          category: 'candidate',
+          operation,
+          text: phrase.text ?? candidate.matchText ?? candidate.label ?? '',
+          source: 'formalizeTextWith.phrases',
+          requiresUserSelection: true,
+          candidate: {
+            id: candidate.id ?? null,
+            label: candidate.label ?? null,
+            description: candidate.description ?? null,
+            sourceUrl: candidate.sourceUrl ?? null,
+            score: candidate.score ?? null,
+          },
+        })
+      );
+    }
+  }
+  return suggestions;
+}
+
+function collectTranslateSuggestions(result, operation) {
+  const questions = [
+    ...(result?.questions ?? []),
+    ...(result?.cst?.questions ?? []),
+    ...(result?.sentences ?? []).flatMap(
+      (sentence) => sentence.questions ?? []
+    ),
+  ];
+  return questions.map((question, index) =>
+    suggestion({
+      id: `translation-question-${index + 1}`,
+      kind: 'translation-question',
+      category: 'candidate',
+      operation,
+      text: String(question.text ?? question.prompt ?? question),
+      source: 'translateTextWith.questions',
+      requiresUserSelection: true,
+      candidate: question,
+    })
+  );
+}
+
+function collectUniquenessSuggestions(result, operation) {
+  const suggestions = [];
+  for (const [statementIndex, statement] of (
+    result?.statements ?? []
+  ).entries()) {
+    for (const [matchIndex, match] of (statement.matches ?? []).entries()) {
+      suggestions.push(
+        suggestion({
+          id:
+            match.id ??
+            `originality-${statementIndex + 1}-match-${matchIndex + 1}`,
+          kind: 'originality-check',
+          category: 'evidence-check',
+          operation,
+          text: statement.text ?? '',
+          source: 'searchTextUniqueness.statements',
+          evidenceBacked: true,
+          result: {
+            suggestedAction: statement.suggestedAction ?? null,
+            score: match.score ?? match.matchStrength ?? null,
+            matchKind: match.matchKind ?? null,
+            sourceUrl: match.sourceUrl ?? null,
+          },
+        })
+      );
+    }
+  }
+  return suggestions;
+}
+
+function suggestion(fields) {
+  return {
+    id: fields.id,
+    kind: fields.kind,
+    category: fields.category,
+    operation: fields.operation,
+    text: fields.text ?? '',
+    explicit: true,
+    evidenceBacked: false,
+    styleRewrite: false,
+    requiresUserSelection: false,
+    source: fields.source,
+    ...fields,
+  };
+}
+
+function collectExports(operation, result, services, reportOptions) {
+  const embeddedExports = {
+    linksNotation: linksNotationFor(result, services),
+  };
+
+  if (operation === WRITING_ASSISTANT_OPERATIONS.ANALYZE) {
+    embeddedExports.issueReportUrl = services.createIssueReportUrl(
+      result,
+      reportOptions
+    );
+  }
+
+  if (operation === WRITING_ASSISTANT_OPERATIONS.CHECK) {
+    const issueReportUrls = (result?.statements ?? [])
+      .filter((statement) => statement.analysis)
+      .map((statement) => ({
+        statementId: statement.id,
+        url: services.createIssueReportUrl(statement.analysis, reportOptions),
+      }));
+    embeddedExports.issueReportUrls = issueReportUrls;
+    if (issueReportUrls[0]) {
+      embeddedExports.issueReportUrl = issueReportUrls[0].url;
+    }
+  }
+
+  return embeddedExports;
+}
+
+function linksNotationFor(result, services) {
+  if (typeof result?.linksNotation === 'string') {
+    return result.linksNotation;
+  }
+  if (result?.linksNetwork) {
+    return services.serializeLinksNotation(result.linksNetwork);
+  }
+  return '';
+}
+
+function collectOperationOptions(operation, request, options) {
+  return stripUndefined({
+    fetch: options.fetch,
+    cache: options.cache,
+    now: options.now,
+    ...objectOrEmpty(options.options),
+    ...objectOrEmpty(options.operationOptions?.[operation]),
+    live: options.live,
+    ...requestScalarOptions(request),
+    ...objectOrEmpty(request.options),
+  });
+}
+
+function collectReportOptions(request, options, context) {
+  const report = isObject(request?.report) ? request.report : {};
+  return stripUndefined({
+    repoUrl: report.repoUrl ?? options.repoUrl,
+    labels: report.labels ?? options.labels,
+    pageUrl: report.pageUrl ?? context.pageUrl ?? context.documentUrl,
+    userAgent: report.userAgent ?? context.userAgent ?? options.userAgent,
+    timestamp: report.timestamp ?? timestampFromNow(options.now),
+  });
+}
+
+function timestampFromNow(now) {
+  if (typeof now !== 'function') {
+    return undefined;
+  }
+  const value = now();
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'number') {
+    return new Date(value).toISOString();
+  }
+  return typeof value === 'string' ? value : undefined;
+}
+
+function mergeServices(services = {}) {
+  return {
+    ...defaultServices,
+    ...objectOrEmpty(services),
+  };
+}
+
+function operationFromRequest(request) {
+  return normalizeOperation(
+    request.operation ?? request.action ?? WRITING_ASSISTANT_OPERATIONS.ANALYZE
+  );
+}
+
+function textFromRequest(request) {
+  return String(request.text ?? request.input ?? '');
+}
+
+function contextFromRequest(request, options) {
+  return normalizeContext({
+    ...objectOrEmpty(options.context),
+    ...objectOrEmpty(request.context),
+  });
+}
+
+function requestScalarOptions(request) {
+  return Object.fromEntries(
+    ['from', 'to', 'sourceLanguage', 'targetLanguage', 'limit', 'live']
+      .filter((key) => request[key] !== undefined)
+      .map((key) => [key, request[key]])
+  );
+}
+
+function normalizeOperation(operation) {
+  const normalized = String(operation ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-');
+  const aliased = operationAliases.get(normalized) ?? normalized;
+  if (Object.values(WRITING_ASSISTANT_OPERATIONS).includes(aliased)) {
+    return aliased;
+  }
+  throw new Error(`Unsupported writing-assistant operation: ${operation}`);
+}
+
+function normalizeSurface(surface) {
+  if (!surface || typeof surface === 'object') {
+    return WRITING_ASSISTANT_SURFACES.EMBEDDED;
+  }
+  const normalized = String(surface).trim().toLowerCase().replace(/_/g, '-');
+  return Object.values(WRITING_ASSISTANT_SURFACES).includes(normalized)
+    ? normalized
+    : WRITING_ASSISTANT_SURFACES.EMBEDDED;
+}
+
+function normalizeContext(context) {
+  if (!isObject(context)) {
+    return {};
+  }
+  const rest = { ...context };
+  delete rest.text;
+  delete rest.input;
+  return stripUndefined(rest);
+}
+
+function stripUndefined(object) {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => value !== undefined)
+  );
+}
+
+function objectOrEmpty(value) {
+  return isObject(value) ? value : {};
+}
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null;
+}

--- a/js/src/writing-assistant.js
+++ b/js/src/writing-assistant.js
@@ -173,39 +173,39 @@ export function createMockWritingAssistantExtensionHarness(options = {}) {
       ? options.surface
       : createWritingAssistantSurface(options);
   const defaultContext = normalizeContext(options.context);
+  const createSelection = (text, context = {}) => ({
+    text: String(text ?? ''),
+    ...defaultContext,
+    ...normalizeContext(context),
+  });
+  const runSelection = (operation, selection, request = {}) => {
+    const selectedText =
+      typeof selection === 'string'
+        ? selection
+        : String(selection?.text ?? request.text ?? '');
+    const selectionContext =
+      typeof selection === 'string' ? {} : normalizeContext(selection);
+    const context = {
+      ...defaultContext,
+      ...selectionContext,
+      ...normalizeContext(request.context),
+    };
+    return assistantSurface.run({
+      ...request,
+      operation,
+      text: selectedText,
+      context,
+    });
+  };
 
   return Object.freeze({
     kind: 'mock-writing-assistant-extension-harness',
     surface: assistantSurface.surface,
     guardrails: assistantSurface.guardrails,
-    createSelection(text, context = {}) {
-      return {
-        text: String(text ?? ''),
-        ...defaultContext,
-        ...normalizeContext(context),
-      };
-    },
-    runSelection(operation, selection, request = {}) {
-      const selectedText =
-        typeof selection === 'string'
-          ? selection
-          : String(selection?.text ?? request.text ?? '');
-      const selectionContext =
-        typeof selection === 'string' ? {} : normalizeContext(selection);
-      const context = {
-        ...defaultContext,
-        ...selectionContext,
-        ...normalizeContext(request.context),
-      };
-      return assistantSurface.run({
-        ...request,
-        operation,
-        text: selectedText,
-        context,
-      });
-    },
+    createSelection,
+    runSelection,
     async verifySelectionExports(operation, selection, request = {}) {
-      const result = await this.runSelection(operation, selection, request);
+      const result = await runSelection(operation, selection, request);
       return verifyWritingAssistantEmbeddedExports(result);
     },
   });

--- a/js/tests/fixtures/issue-94/mock-extension-selection.json
+++ b/js/tests/fixtures/issue-94/mock-extension-selection.json
@@ -1,0 +1,13 @@
+{
+  "selection": {
+    "text": "Moon orbits Earth.",
+    "pageUrl": "https://example.test/editor/document-42",
+    "userAgent": "MockBrowserExtension/94",
+    "selectionStart": 128,
+    "selectionEnd": 146
+  },
+  "report": {
+    "labels": "bug,writing-assistant",
+    "timestamp": "2026-05-26T00:00:00.000Z"
+  }
+}

--- a/js/tests/integration/issue-94-writing-assistant-surface.test.js
+++ b/js/tests/integration/issue-94-writing-assistant-surface.test.js
@@ -208,5 +208,16 @@ describe('issue 94 - browser/editor writing assistant surface', () => {
             suggestion.styleRewrite === false
         )
     ).toBe(true);
+
+    const verifySelectionExports = harness.verifySelectionExports;
+    const verification = await verifySelectionExports(
+      WRITING_ASSISTANT_OPERATIONS.ANALYZE,
+      selection,
+      { report: fixture.report }
+    );
+
+    expect(verification.ok).toBe(true);
+    expect(verification.linksNotation).toBe(true);
+    expect(verification.issueReportUrl).toBe(true);
   });
 });

--- a/js/tests/integration/issue-94-writing-assistant-surface.test.js
+++ b/js/tests/integration/issue-94-writing-assistant-surface.test.js
@@ -1,0 +1,212 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'test-anywhere';
+import {
+  WRITING_ASSISTANT_OPERATIONS,
+  analyzeStatement,
+  checkText,
+  createMockWritingAssistantExtensionHarness,
+  createWritingAssistantSurface,
+} from '../../src/index.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL(
+      '../fixtures/issue-94/mock-extension-selection.json',
+      import.meta.url
+    ),
+    'utf8'
+  )
+);
+
+function createDelegatingServices(calls) {
+  return {
+    analyzeStatement(input, options) {
+      calls.push({ operation: WRITING_ASSISTANT_OPERATIONS.ANALYZE, input });
+      return analyzeStatement(input, options);
+    },
+    checkText(input, options) {
+      calls.push({ operation: WRITING_ASSISTANT_OPERATIONS.CHECK, input });
+      return checkText(input, options);
+    },
+    async formalizeTextWith(input) {
+      calls.push({ operation: WRITING_ASSISTANT_OPERATIONS.FORMALIZE, input });
+      return {
+        status: 'completed',
+        text: input,
+        phrases: [
+          {
+            text: 'Moon',
+            candidates: [
+              {
+                id: 'Q405',
+                label: 'Moon',
+                description: 'natural satellite of Earth',
+                sourceUrl: 'https://www.wikidata.org/wiki/Q405',
+                score: 1,
+              },
+            ],
+          },
+        ],
+        linksNotation: '(formalize-result: fixture)',
+        markdown: '[Moon](https://www.wikidata.org/wiki/Q405) orbits Earth.',
+        html: '<a href="https://www.wikidata.org/wiki/Q405">Moon</a> orbits Earth.',
+      };
+    },
+    async translateTextWith(input) {
+      calls.push({ operation: WRITING_ASSISTANT_OPERATIONS.TRANSLATE, input });
+      return {
+        status: 'translated',
+        text: input,
+        linksNotation: '(translate-result: fixture)',
+        markdown: 'Moon orbits Earth.',
+        html: 'Moon orbits Earth.',
+      };
+    },
+    async searchTextUniqueness(input) {
+      calls.push({ operation: WRITING_ASSISTANT_OPERATIONS.UNIQUENESS, input });
+      return {
+        status: 'checked',
+        text: input,
+        statements: [
+          {
+            id: 'statement-1',
+            text: input,
+            suggestedAction: 'cite-or-quote',
+            matches: [
+              {
+                id: 'match-1',
+                sourceUrl: 'https://example.test/source/moon-earth',
+                title: 'Moon and Earth fixture',
+                score: 0.91,
+                matchKind: 'exact-passage',
+              },
+            ],
+          },
+        ],
+        linksNotation: '(uniqueness-result: fixture)',
+      };
+    },
+  };
+}
+
+describe('issue 94 - browser/editor writing assistant surface', () => {
+  it('delegates embedded operations to existing APIs and preserves guardrails', async () => {
+    const calls = [];
+    const surface = createWritingAssistantSurface({
+      surface: 'editor-extension',
+      services: createDelegatingServices(calls),
+      now: () => fixture.report.timestamp,
+    });
+
+    const operations = [
+      WRITING_ASSISTANT_OPERATIONS.ANALYZE,
+      WRITING_ASSISTANT_OPERATIONS.CHECK,
+      WRITING_ASSISTANT_OPERATIONS.FORMALIZE,
+      WRITING_ASSISTANT_OPERATIONS.TRANSLATE,
+      WRITING_ASSISTANT_OPERATIONS.UNIQUENESS,
+    ];
+    const results = [];
+
+    for (const operation of operations) {
+      results.push(
+        await surface.run({
+          operation,
+          text: fixture.selection.text,
+          context: fixture.selection,
+          report: fixture.report,
+          options: {
+            sourceLanguage: 'en',
+            targetLanguage: 'ru',
+            limit: 1,
+          },
+        })
+      );
+    }
+
+    expect(calls.map((call) => call.operation)).toEqual(operations);
+    expect(calls.every((call) => call.input === fixture.selection.text)).toBe(
+      true
+    );
+    expect(
+      results.every((result) => result.exports.linksNotation.length > 0)
+    ).toBe(true);
+    expect(
+      results.every(
+        (result) =>
+          result.guardrails.candidateSuggestionsExplicit === true &&
+          result.guardrails.evidenceChecksAreStyleRewrites === false
+      )
+    ).toBe(true);
+
+    const checkResult = results.find(
+      (result) => result.operation === WRITING_ASSISTANT_OPERATIONS.CHECK
+    );
+    const evidenceSuggestion = checkResult.suggestions.find(
+      (suggestion) => suggestion.kind === 'evidence-check'
+    );
+    expect(evidenceSuggestion.evidenceBacked).toBe(true);
+    expect(evidenceSuggestion.styleRewrite).toBe(false);
+
+    const formalizeResult = results.find(
+      (result) => result.operation === WRITING_ASSISTANT_OPERATIONS.FORMALIZE
+    );
+    const candidateSuggestion = formalizeResult.suggestions.find(
+      (suggestion) => suggestion.kind === 'candidate-formalization-link'
+    );
+    expect(candidateSuggestion.explicit).toBe(true);
+    expect(candidateSuggestion.requiresUserSelection).toBe(true);
+    expect(candidateSuggestion.evidenceBacked).toBe(false);
+  });
+
+  it('keeps prefilled report URLs and Links Notation exports in a mock extension harness', async () => {
+    const harness = createMockWritingAssistantExtensionHarness({
+      surface: 'browser-extension',
+      now: () => fixture.report.timestamp,
+    });
+    const selection = harness.createSelection(
+      fixture.selection.text,
+      fixture.selection
+    );
+
+    const analysisResult = await harness.runSelection(
+      WRITING_ASSISTANT_OPERATIONS.ANALYZE,
+      selection,
+      { report: fixture.report }
+    );
+    const reportUrl = new URL(analysisResult.exports.issueReportUrl);
+    const reportBody = reportUrl.searchParams.get('body');
+
+    expect(analysisResult.exports.linksNotation).toContain('(links-network');
+    expect(reportBody).toContain(fixture.selection.text);
+    expect(reportBody).toContain('## Links Notation');
+    expect(reportBody).toContain(fixture.selection.pageUrl);
+    expect(
+      analysisResult.suggestions
+        .filter((suggestion) => suggestion.kind === 'candidate-interpretation')
+        .every(
+          (suggestion) =>
+            suggestion.explicit === true &&
+            suggestion.styleRewrite === false &&
+            suggestion.evidenceBacked === false
+        )
+    ).toBe(true);
+
+    const checkResult = await harness.runSelection(
+      WRITING_ASSISTANT_OPERATIONS.CHECK,
+      selection,
+      { report: fixture.report }
+    );
+
+    expect(checkResult.exports.linksNotation).toContain('check');
+    expect(checkResult.exports.issueReportUrls.length).toBeGreaterThan(0);
+    expect(
+      checkResult.suggestions
+        .filter((suggestion) => suggestion.kind === 'evidence-check')
+        .every(
+          (suggestion) =>
+            suggestion.evidenceBacked === true &&
+            suggestion.styleRewrite === false
+        )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #94

## Summary

- Added a reusable writing-assistant surface for browser/editor/document integrations that delegates to the existing analyze, check, formalize, translate, and uniqueness APIs.
- Added guardrail metadata and suggestion typing so candidate interpretations/formalization links stay explicit and evidence-backed checks remain separate from style rewrites.
- Added a mock extension harness plus fixture coverage for embedded selections, prefilled report URLs, and Links Notation exports.
- Documented the new surface in the README and issue 94 case study.

## Verification

- `node --test js/tests/integration/issue-94-writing-assistant-surface.test.js`
- `npm run lint`
- `npm run format:check`
- `npm run test:integration`
- `npm run check`
- `npm test`