### PR TITLE
Add unified Wikimedia term data source (#108)

### DIFF
--- a/.changeset/issue-108-term-data-source.md
+++ b/.changeset/issue-108-term-data-source.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': minor
+---
+
+Add a unified on-demand Wikimedia term data source with per-field provenance and Links Notation/binary cache artifacts.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T20:10:39.154Z for PR creation at branch issue-108-9ec72bf0c00d for issue https://github.com/link-assistant/meta-expression/issues/108

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -736,6 +736,68 @@ export interface WikimediaEvidenceClient {
   ): Promise<EvidenceItem[]>;
 }
 
+export interface TermFieldProvenance {
+  source: string;
+  sourceField: string;
+  targetField: string;
+  mergeStrategy: string;
+  sourceUrl: string | null;
+  retrievedAt: string | null;
+}
+
+export interface TermDataRecord {
+  kind: 'term-data';
+  version: number;
+  term: string;
+  normalizedTerm: string;
+  language: string;
+  retrievedAt: string;
+  fields: Record<string, unknown>;
+  sources: Record<string, unknown>;
+  provenance: {
+    fields: Record<string, TermFieldProvenance[]>;
+    requests: Array<Record<string, unknown>>;
+  };
+}
+
+export interface TermDataArtifacts {
+  linksNotation: string;
+  binary: Uint8Array;
+}
+
+export type TermDataFetch = (
+  input: string | URL,
+  init?: Record<string, unknown>
+) => Promise<{
+  ok: boolean;
+  status: number;
+  headers?: { get(name: string): string | null };
+  json(): Promise<unknown>;
+}>;
+
+export interface TermDataResult extends TermDataRecord {
+  artifacts: TermDataArtifacts;
+}
+
+export interface TermDataSource {
+  cache: Map<string, unknown>;
+  getTerm(
+    term: string,
+    options?: TermDataSourceOptions
+  ): Promise<TermDataResult>;
+}
+
+export interface TermDataSourceOptions {
+  cache?: Map<string, unknown>;
+  cacheTtlMs?: number;
+  cacheJitterMs?: number;
+  cacheJitterMinMs?: number;
+  fetch?: TermDataFetch;
+  fetchImpl?: TermDataFetch;
+  language?: string;
+  now?: () => number;
+}
+
 export declare const defaultBeliefSystem: BeliefSystem;
 
 export declare const preferenceBeliefDefinitions: readonly PreferenceBeliefDefinition[];
@@ -912,6 +974,19 @@ export declare function resolveLiveEvidence(
   input: string,
   options?: AnalysisOptions
 ): Promise<EvidenceItem[]>;
+
+export declare function createTermDataSource(
+  options?: TermDataSourceOptions
+): TermDataSource;
+
+export declare function getTerm(
+  term: string,
+  options?: TermDataSourceOptions
+): Promise<TermDataResult>;
+
+export declare function parseTermDataLinksNotation(
+  text: string
+): TermDataRecord | unknown;
 
 export declare function generateInterpretations(
   input: string,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -21,6 +21,11 @@ export {
   createWikimediaEvidenceClient,
   resolveLiveEvidence,
 } from './wikimedia-evidence.js';
+export {
+  createTermDataSource,
+  getTerm,
+  parseTermDataLinksNotation,
+} from './term-data-source.js';
 export { computeEvidenceConfidence } from './evidence-scoring.js';
 export {
   createProbabilityCalculation,

--- a/js/src/term-data-source.js
+++ b/js/src/term-data-source.js
@@ -1,0 +1,743 @@
+import { encodeAsDoublets } from './doublets.js';
+import { parseLino, serializeLino } from './lino.js';
+import { fetchWikimediaJson } from './wikimedia-fetch.js';
+
+const defaultLanguage = 'en';
+const defaultCacheTtlMs = 7 * 24 * 60 * 60 * 1000;
+const defaultTermDataCache = new Map();
+const wikidataApiUrl = 'https://www.wikidata.org/w/api.php';
+const wikidataEntityBaseUrl = 'https://www.wikidata.org/wiki/';
+
+export function createTermDataSource(options = {}) {
+  const cache = options.cache ?? new Map();
+  const config = createConfig({ ...options, cache });
+  return {
+    cache,
+    async getTerm(term, overrideOptions = {}) {
+      const overrideFetchImpl =
+        overrideOptions.fetchImpl ?? overrideOptions.fetch;
+      return await getTermFromConfig(term, {
+        ...config,
+        ...overrideOptions,
+        cache,
+        fetchImpl: overrideFetchImpl ?? config.fetchImpl,
+      });
+    },
+  };
+}
+
+export async function getTerm(term, options = {}) {
+  const source = createTermDataSource({
+    ...options,
+    cache: options.cache ?? defaultTermDataCache,
+  });
+  return await source.getTerm(term);
+}
+
+export function parseTermDataLinksNotation(text) {
+  const parsed = parseLino(text);
+  if (parsed?.record && typeof parsed.record === 'object') {
+    return parsed.record;
+  }
+  if (parsed?.['term-data']?.record) {
+    return parsed['term-data'].record;
+  }
+  return parsed;
+}
+
+async function getTermFromConfig(input, config) {
+  const term = normalizeTerm(input);
+  const language = normalizeLanguage(config.language);
+  const key = termCacheKey(term, language);
+  const cached = readMergedCacheEntry(config.cache, key, config);
+  if (cached) {
+    return cached;
+  }
+
+  const retrievedAt = retrievalTimestamp(config);
+  const [wikidata, wiktionary] = await Promise.all([
+    resolveWikidataTerm(term, language, config),
+    resolveWiktionaryTerm(term, language, config),
+  ]);
+  const wikipedia = await resolveWikipediaTerm(
+    term,
+    language,
+    wikidata,
+    config
+  );
+  const record = buildMergedRecord({
+    term,
+    language,
+    retrievedAt,
+    wikidata,
+    wikipedia,
+    wiktionary,
+  });
+  const artifacts = createMergedArtifacts(record);
+  config.cache.set(key, {
+    expiresAt: Number(config.now()) + cacheTtlMs(config),
+    value: record,
+    artifacts,
+  });
+  return withArtifacts(record, artifacts);
+}
+
+function createConfig(options) {
+  const fetchImpl = options.fetchImpl ?? options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('Term data resolution requires a fetch implementation.');
+  }
+  return {
+    cache: options.cache ?? new Map(),
+    cacheTtlMs: options.cacheTtlMs ?? defaultCacheTtlMs,
+    cacheJitterMs: options.cacheJitterMs,
+    cacheJitterMinMs: options.cacheJitterMinMs,
+    language: options.language ?? defaultLanguage,
+    now: options.now ?? Date.now,
+    fetchImpl: fetchImpl.bind?.(globalThis) ?? fetchImpl,
+  };
+}
+
+// eslint-disable-next-line complexity
+async function resolveWikidataTerm(term, language, config) {
+  const search = await fetchWikidataSearch(term, language, config);
+  const selected = chooseWikidataSearchResult(term, search?.search ?? []);
+  if (!selected?.id) {
+    return null;
+  }
+  const entity = await fetchWikidataEntity(selected.id, language, config);
+  if (!entity) {
+    return null;
+  }
+  return {
+    source: 'wikidata',
+    id: entity.id,
+    label: entity.labels?.[language]?.value ?? selected.label ?? term,
+    description:
+      entity.descriptions?.[language]?.value ?? selected.description ?? '',
+    aliases: (entity.aliases?.[language] ?? [])
+      .map((entry) => entry?.value)
+      .filter((value) => typeof value === 'string' && value),
+    claims: compactClaims(entity.claims ?? {}),
+    sitelinks: compactSitelinks(entity.sitelinks ?? {}),
+    sourceUrl: wikidataEntityUrl(entity.id),
+  };
+}
+
+async function fetchWikidataSearch(term, language, config) {
+  const url = new URL(wikidataApiUrl);
+  url.search = new URLSearchParams({
+    action: 'wbsearchentities',
+    format: 'json',
+    language,
+    limit: '5',
+    origin: '*',
+    search: term,
+    type: 'item',
+  }).toString();
+  return await fetchSourceJson(url, config, {
+    requestKind: 'wikidata-search',
+    source: 'wikidata',
+    term,
+    language,
+  });
+}
+
+async function fetchWikidataEntity(id, language, config) {
+  const url = new URL(wikidataApiUrl);
+  url.search = new URLSearchParams({
+    action: 'wbgetentities',
+    format: 'json',
+    ids: id,
+    languages: language,
+    origin: '*',
+    props: 'labels|aliases|descriptions|claims|sitelinks',
+    sitefilter: `${language}wiki`,
+  }).toString();
+  const payload = await fetchSourceJson(url, config, {
+    requestKind: 'wikidata-entity',
+    source: 'wikidata',
+    term: id,
+    language,
+  });
+  const entity = payload?.entities?.[id];
+  return entity && !entity.missing ? entity : null;
+}
+
+// eslint-disable-next-line complexity
+async function resolveWikipediaTerm(term, language, wikidata, config) {
+  const title =
+    wikidata?.sitelinks?.[`${language}wiki`]?.title ??
+    (await searchWikipediaTitle(term, language, config));
+  if (!title) {
+    return null;
+  }
+  const summary = await fetchWikipediaSummary(title, language, config);
+  if (!summary) {
+    return null;
+  }
+  return {
+    source: 'wikipedia',
+    title: summary.title ?? title,
+    description: summary.description ?? '',
+    extract: summary.extract ?? '',
+    url:
+      summary.content_urls?.desktop?.page ??
+      wikipediaArticleUrl(language, summary.title ?? title),
+    sourceUrl:
+      summary.content_urls?.desktop?.page ??
+      wikipediaArticleUrl(language, summary.title ?? title),
+    wikibaseId: wikidata?.id ?? null,
+  };
+}
+
+async function searchWikipediaTitle(term, language, config) {
+  const url = new URL(`https://${language}.wikipedia.org/w/api.php`);
+  url.search = new URLSearchParams({
+    action: 'query',
+    format: 'json',
+    list: 'search',
+    origin: '*',
+    srlimit: '1',
+    srsearch: term,
+  }).toString();
+  try {
+    const payload = await fetchSourceJson(url, config, {
+      requestKind: 'wikipedia-search',
+      source: 'wikipedia',
+      term,
+      language,
+    });
+    return payload?.query?.search?.[0]?.title ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchWikipediaSummary(title, language, config) {
+  const url = new URL(
+    encodeURIComponent(title),
+    `https://${language}.wikipedia.org/api/rest_v1/page/summary/`
+  );
+  try {
+    return await fetchSourceJson(url, config, {
+      requestKind: 'wikipedia-summary',
+      source: 'wikipedia',
+      term: title,
+      language,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function resolveWiktionaryTerm(term, language, config) {
+  const pageTitle = wiktionaryPageTitle(term);
+  if (!pageTitle) {
+    return null;
+  }
+  const url = new URL(
+    `https://${language}.wiktionary.org/api/rest_v1/page/definition/${encodeURIComponent(
+      pageTitle
+    )}`
+  );
+  let payload;
+  try {
+    payload = await fetchSourceJson(url, config, {
+      requestKind: 'wiktionary-definition',
+      source: 'wiktionary',
+      term: pageTitle,
+      language,
+    });
+  } catch {
+    return null;
+  }
+  const entries = wiktionaryEntries(payload?.[language]);
+  if (entries.length === 0) {
+    return null;
+  }
+  return {
+    source: 'wiktionary',
+    pageTitle,
+    entries,
+    sourceUrl: wiktionaryArticleUrl(language, pageTitle),
+  };
+}
+
+async function fetchSourceJson(url, config, metadata) {
+  const key = String(url);
+  try {
+    const value = await fetchWikimediaJson(url, config);
+    enrichRequestCacheEntry(config.cache, key, value, config, metadata);
+    return value;
+  } catch (error) {
+    enrichRequestCacheEntry(config.cache, key, null, config, metadata, error);
+    throw error;
+  }
+}
+
+function enrichRequestCacheEntry(cache, key, value, config, metadata, error) {
+  const entry = cache.get(key);
+  if (!entry || entry.artifacts) {
+    return;
+  }
+  const retrievedAt = entry.retrievedAt ?? retrievalTimestamp(config);
+  entry.retrievedAt = retrievedAt;
+  const payload = {
+    kind: 'term-data-request',
+    source: metadata.source,
+    requestKind: metadata.requestKind,
+    term: metadata.term,
+    language: metadata.language,
+    retrievedAt,
+    request: { url: key },
+    response: value ?? null,
+    error: error
+      ? {
+          message: error.message,
+          status: error.status ?? null,
+        }
+      : null,
+  };
+  entry.artifacts = createRequestArtifacts(payload);
+}
+
+// eslint-disable-next-line complexity
+function buildMergedRecord({
+  term,
+  language,
+  retrievedAt,
+  wikidata,
+  wikipedia,
+  wiktionary,
+}) {
+  const provenance = {
+    fields: {},
+    requests: sourceRequests({ wikidata, wikipedia, wiktionary }),
+  };
+  const fields = {};
+
+  addField(fields, provenance, 'id', wikidata?.id, [
+    fieldProvenance('wikidata', 'id', 'fields.id', {
+      mergeStrategy: 'prefer-wikidata-id',
+      sourceUrl: wikidata?.sourceUrl,
+      retrievedAt,
+    }),
+  ]);
+  addField(fields, provenance, 'label', wikidata?.label ?? wikipedia?.title, [
+    fieldProvenance(
+      wikidata?.label ? 'wikidata' : 'wikipedia',
+      wikidata?.label ? 'label' : 'title',
+      'fields.label',
+      {
+        mergeStrategy: wikidata?.label
+          ? 'prefer-wikidata-label'
+          : 'fallback-wikipedia-title',
+        sourceUrl: wikidata?.sourceUrl ?? wikipedia?.sourceUrl,
+        retrievedAt,
+      }
+    ),
+  ]);
+  addField(
+    fields,
+    provenance,
+    'description',
+    wikidata?.description ||
+      wikipedia?.description ||
+      firstDefinition(wiktionary),
+    [
+      descriptionProvenance({
+        wikidata,
+        wikipedia,
+        wiktionary,
+        retrievedAt,
+      }),
+    ]
+  );
+  addField(fields, provenance, 'aliases', wikidata?.aliases ?? [], [
+    fieldProvenance('wikidata', 'aliases', 'fields.aliases', {
+      mergeStrategy: 'copy-wikidata-aliases',
+      sourceUrl: wikidata?.sourceUrl,
+      retrievedAt,
+    }),
+  ]);
+  addField(fields, provenance, 'claims', wikidata?.claims ?? {}, [
+    fieldProvenance('wikidata', 'claims', 'fields.claims', {
+      mergeStrategy: 'compact-wikidata-claims',
+      sourceUrl: wikidata?.sourceUrl,
+      retrievedAt,
+    }),
+  ]);
+  addField(fields, provenance, 'wikipediaTitle', wikipedia?.title, [
+    fieldProvenance('wikipedia', 'title', 'fields.wikipediaTitle', {
+      mergeStrategy: 'copy-wikipedia-summary-title',
+      sourceUrl: wikipedia?.sourceUrl,
+      retrievedAt,
+    }),
+  ]);
+  addField(fields, provenance, 'wikipediaSummary', wikipedia?.extract, [
+    fieldProvenance('wikipedia', 'extract', 'fields.wikipediaSummary', {
+      mergeStrategy: 'copy-wikipedia-summary-extract',
+      sourceUrl: wikipedia?.sourceUrl,
+      retrievedAt,
+    }),
+  ]);
+  addField(fields, provenance, 'wiktionaryEntries', wiktionary?.entries ?? [], [
+    fieldProvenance('wiktionary', 'definitions', 'fields.wiktionaryEntries', {
+      mergeStrategy: 'copy-wiktionary-lexical-entries',
+      sourceUrl: wiktionary?.sourceUrl,
+      retrievedAt,
+    }),
+  ]);
+  addField(
+    fields,
+    provenance,
+    'sourceUrls',
+    sourceUrls(wikidata, wikipedia, wiktionary),
+    [
+      fieldProvenance('wikimedia', 'sourceUrl', 'fields.sourceUrls', {
+        mergeStrategy: 'merge-source-urls-by-source',
+        retrievedAt,
+      }),
+    ]
+  );
+
+  return pruneEmpty({
+    kind: 'term-data',
+    version: 1,
+    term,
+    normalizedTerm: normalizeKey(term),
+    language,
+    retrievedAt,
+    fields,
+    sources: pruneEmpty({
+      wikidata,
+      wikipedia,
+      wiktionary,
+    }),
+    provenance,
+  });
+}
+
+function addField(fields, provenance, name, value, fieldProvenanceEntries) {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return;
+  }
+  if (isPlainObject(value) && Object.keys(value).length === 0) {
+    return;
+  }
+  fields[name] = value;
+  provenance.fields[name] = fieldProvenanceEntries.filter(Boolean);
+}
+
+function fieldProvenance(source, sourceField, targetField, options = {}) {
+  if (!source || !sourceField || !targetField) {
+    return null;
+  }
+  return {
+    source,
+    sourceField,
+    targetField,
+    mergeStrategy: options.mergeStrategy ?? 'copy',
+    sourceUrl: options.sourceUrl ?? null,
+    retrievedAt: options.retrievedAt ?? null,
+  };
+}
+
+function descriptionProvenance({
+  wikidata,
+  wikipedia,
+  wiktionary,
+  retrievedAt,
+}) {
+  if (wikidata?.description) {
+    return fieldProvenance('wikidata', 'description', 'fields.description', {
+      mergeStrategy: 'prefer-wikidata-description',
+      sourceUrl: wikidata.sourceUrl,
+      retrievedAt,
+    });
+  }
+  if (wikipedia?.description) {
+    return fieldProvenance('wikipedia', 'description', 'fields.description', {
+      mergeStrategy: 'fallback-wikipedia-description',
+      sourceUrl: wikipedia.sourceUrl,
+      retrievedAt,
+    });
+  }
+  if (firstDefinition(wiktionary)) {
+    return fieldProvenance('wiktionary', 'definitions', 'fields.description', {
+      mergeStrategy: 'fallback-first-wiktionary-definition',
+      sourceUrl: wiktionary.sourceUrl,
+      retrievedAt,
+    });
+  }
+  return null;
+}
+
+function firstDefinition(wiktionary) {
+  return wiktionary?.entries?.[0]?.definitions?.[0] ?? '';
+}
+
+function sourceUrls(wikidata, wikipedia, wiktionary) {
+  return pruneEmpty({
+    wikidata: wikidata?.sourceUrl,
+    wikipedia: wikipedia?.sourceUrl,
+    wiktionary: wiktionary?.sourceUrl,
+  });
+}
+
+function sourceRequests(sources) {
+  const requests = [];
+  for (const [source, value] of Object.entries(sources)) {
+    if (!value?.sourceUrl) {
+      continue;
+    }
+    requests.push({
+      source,
+      sourceUrl: value.sourceUrl,
+    });
+  }
+  return requests;
+}
+
+function chooseWikidataSearchResult(term, results) {
+  if (!Array.isArray(results) || results.length === 0) {
+    return null;
+  }
+  const normalized = normalizeKey(term);
+  return results
+    .map((result, index) => ({
+      result,
+      index,
+      score: wikidataSearchScore(normalized, result),
+    }))
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .at(0).result;
+}
+
+function wikidataSearchScore(normalizedTerm, result) {
+  const label = normalizeKey(result.label ?? '');
+  const match = normalizeKey(result.match?.text ?? '');
+  let score = 0;
+  if (label === normalizedTerm) {
+    score += 20;
+  } else if (label.includes(normalizedTerm)) {
+    score += 5;
+  }
+  if (match === normalizedTerm) {
+    score += 5;
+  }
+  return score;
+}
+
+function compactClaims(claims) {
+  const compact = {};
+  for (const [property, entries] of Object.entries(claims)) {
+    const values = (Array.isArray(entries) ? entries : [])
+      .map(compactClaimValue)
+      .filter(Boolean);
+    if (values.length > 0) {
+      compact[property] = values;
+    }
+  }
+  return compact;
+}
+
+function compactClaimValue(claim) {
+  const datavalue = claim?.mainsnak?.datavalue;
+  const value = datavalue?.value;
+  if (!value) {
+    return null;
+  }
+  if (typeof value === 'object' && value.id) {
+    return {
+      type: datavalue.type ?? 'wikibase-entityid',
+      id: value.id,
+    };
+  }
+  if (typeof value === 'object' && value.time) {
+    return {
+      type: datavalue.type ?? 'time',
+      time: value.time,
+    };
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return {
+      type: datavalue.type ?? typeof value,
+      value,
+    };
+  }
+  return {
+    type: datavalue.type ?? 'value',
+    value: JSON.stringify(value),
+  };
+}
+
+function compactSitelinks(sitelinks) {
+  const compact = {};
+  for (const [site, value] of Object.entries(sitelinks)) {
+    if (typeof value?.title === 'string') {
+      compact[site] = {
+        title: value.title,
+      };
+    }
+  }
+  return compact;
+}
+
+function wiktionaryEntries(entries) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .map((entry) => ({
+      partOfSpeech: entry?.partOfSpeech ?? null,
+      definitions: (Array.isArray(entry?.definitions) ? entry.definitions : [])
+        .map((definition) => stripHtml(definition?.definition ?? ''))
+        .filter(Boolean),
+    }))
+    .filter((entry) => entry.definitions.length > 0);
+}
+
+function stripHtml(text) {
+  return String(text ?? '').replace(/<[^>]+>/g, '');
+}
+
+function createMergedArtifacts(record) {
+  return {
+    linksNotation: serializeLino(
+      { record },
+      {
+        rootIdentifier: 'term-data',
+      }
+    ),
+    binary: encodeAsDoublets(record).binary,
+  };
+}
+
+function createRequestArtifacts(payload) {
+  return {
+    linksNotation: serializeLino(
+      { request: payload },
+      {
+        rootIdentifier: 'term-data-request',
+      }
+    ),
+    binary: encodeAsDoublets(payload).binary,
+  };
+}
+
+function readMergedCacheEntry(cache, key, config) {
+  const entry = cache.get(key);
+  if (!entry) {
+    return null;
+  }
+  if (entry.expiresAt <= Number(config.now())) {
+    cache.delete(key);
+    return null;
+  }
+  const artifacts = entry.artifacts ?? createMergedArtifacts(entry.value);
+  entry.artifacts = artifacts;
+  return withArtifacts(entry.value, artifacts);
+}
+
+function withArtifacts(record, artifacts) {
+  return {
+    ...cloneJson(record),
+    artifacts,
+  };
+}
+
+function pruneEmpty(value) {
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const out = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === undefined || entry === null) {
+      continue;
+    }
+    if (Array.isArray(entry) && entry.length === 0) {
+      continue;
+    }
+    if (isPlainObject(entry) && Object.keys(entry).length === 0) {
+      continue;
+    }
+    out[key] = entry;
+  }
+  return out;
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function normalizeTerm(input) {
+  if (typeof input !== 'string') {
+    throw new TypeError('Term input must be a string.');
+  }
+  const text = input.trim().replace(/\s+/g, ' ');
+  if (!text) {
+    throw new Error('Term input cannot be empty.');
+  }
+  return text;
+}
+
+function normalizeLanguage(value) {
+  const language = String(value ?? defaultLanguage)
+    .trim()
+    .toLowerCase();
+  return language || defaultLanguage;
+}
+
+function normalizeKey(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function termCacheKey(term, language) {
+  return `term-data:${language}:${normalizeKey(term)}`;
+}
+
+function wiktionaryPageTitle(term) {
+  return normalizeKey(term).replace(/\s+/g, '_');
+}
+
+function wikidataEntityUrl(id) {
+  return `${wikidataEntityBaseUrl}${encodeURIComponent(id)}`;
+}
+
+function wikipediaArticleUrl(language, title) {
+  return `https://${language}.wikipedia.org/wiki/${encodeURIComponent(
+    String(title ?? '').replace(/\s+/g, '_')
+  )}`;
+}
+
+function wiktionaryArticleUrl(language, pageTitle) {
+  return `https://${language}.wiktionary.org/wiki/${encodeURIComponent(
+    pageTitle
+  )}`;
+}
+
+function retrievalTimestamp(config) {
+  return new Date(Number(config.now())).toISOString();
+}
+
+function cacheTtlMs(config) {
+  const ttl = Number(config.cacheTtlMs);
+  return Number.isFinite(ttl) && ttl >= 0 ? ttl : defaultCacheTtlMs;
+}

--- a/js/tests/unit/issue-108.test.js
+++ b/js/tests/unit/issue-108.test.js
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'test-anywhere';
+import {
+  createTermDataSource,
+  decodeFromDoublets,
+  getTerm,
+  parseTermDataLinksNotation,
+} from '../../src/index.js';
+
+function jsonResponse(payload) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    async json() {
+      return payload;
+    },
+  });
+}
+
+function wikidataSearchPayload() {
+  return {
+    search: [
+      {
+        id: 'Q89',
+        label: 'apple',
+        description: 'fruit of the apple tree',
+        match: { type: 'label', text: 'apple' },
+      },
+    ],
+  };
+}
+
+function wikidataEntityPayload() {
+  return {
+    entities: {
+      Q89: {
+        id: 'Q89',
+        labels: { en: { value: 'apple' } },
+        aliases: { en: [{ value: 'malus domestica' }] },
+        descriptions: { en: { value: 'fruit of the apple tree' } },
+        claims: {
+          P31: [
+            {
+              mainsnak: {
+                datavalue: {
+                  type: 'wikibase-entityid',
+                  value: { id: 'Q3314483', 'numeric-id': 3314483 },
+                },
+              },
+            },
+          ],
+        },
+        sitelinks: { enwiki: { title: 'Apple' } },
+      },
+    },
+  };
+}
+
+function wikipediaSummaryPayload() {
+  return {
+    title: 'Apple',
+    extract: 'An apple is an edible fruit produced by an apple tree.',
+    description: 'edible fruit',
+    content_urls: {
+      desktop: { page: 'https://en.wikipedia.org/wiki/Apple' },
+    },
+  };
+}
+
+function wiktionaryDefinitionPayload() {
+  return {
+    en: [
+      {
+        partOfSpeech: 'Noun',
+        definitions: [
+          { definition: 'A common, round fruit produced by an apple tree.' },
+        ],
+      },
+    ],
+  };
+}
+
+function makeFetch(calls) {
+  return async function fetchFixture(url) {
+    calls.push(String(url));
+    const parsed = new URL(String(url));
+    if (
+      parsed.hostname === 'www.wikidata.org' &&
+      parsed.searchParams.get('action') === 'wbsearchentities'
+    ) {
+      return jsonResponse(wikidataSearchPayload());
+    }
+    if (
+      parsed.hostname === 'www.wikidata.org' &&
+      parsed.searchParams.get('action') === 'wbgetentities'
+    ) {
+      return jsonResponse(wikidataEntityPayload());
+    }
+    if (parsed.hostname === 'en.wikipedia.org') {
+      return jsonResponse(wikipediaSummaryPayload());
+    }
+    if (parsed.hostname === 'en.wiktionary.org') {
+      return jsonResponse(wiktionaryDefinitionPayload());
+    }
+    return jsonResponse({});
+  };
+}
+
+describe('issue 108 - unified term data source', () => {
+  it('merges Wikimedia term data with provenance and dual cache artifacts', async () => {
+    const calls = [];
+    const cache = new Map();
+    const source = createTermDataSource({
+      cache,
+      cacheJitterMs: 0,
+      cacheTtlMs: 1000,
+      fetch: makeFetch(calls),
+      now: () => 0,
+    });
+
+    const first = await source.getTerm('apple');
+
+    expect(first.kind).toBe('term-data');
+    expect(first.fields.id).toBe('Q89');
+    expect(first.fields.label).toBe('apple');
+    expect(first.fields.description).toBe('fruit of the apple tree');
+    expect(first.fields.wikipediaTitle).toBe('Apple');
+    expect(first.fields.wikipediaSummary).toContain('edible fruit');
+    expect(first.fields.wiktionaryEntries[0].partOfSpeech).toBe('Noun');
+    expect(first.fields.claims.P31[0].id).toBe('Q3314483');
+
+    expect(first.provenance.fields.label[0].source).toBe('wikidata');
+    expect(first.provenance.fields.wikipediaSummary[0].source).toBe(
+      'wikipedia'
+    );
+    expect(first.provenance.fields.wiktionaryEntries[0].source).toBe(
+      'wiktionary'
+    );
+    expect(first.provenance.fields.wiktionaryEntries[0].targetField).toBe(
+      'fields.wiktionaryEntries'
+    );
+
+    const parsed = parseTermDataLinksNotation(first.artifacts.linksNotation);
+    expect(parsed.fields.id).toBe('Q89');
+    expect(parsed.provenance.fields.label[0].mergeStrategy).toBe(
+      'prefer-wikidata-label'
+    );
+
+    const decoded = decodeFromDoublets(first.artifacts.binary);
+    expect(decoded.fields.wikipediaTitle).toBe('Apple');
+
+    const rawCacheEntries = [...cache.entries()].filter(([key]) =>
+      key.startsWith('https://')
+    );
+    expect(rawCacheEntries.length).toBe(4);
+    for (const [, entry] of rawCacheEntries) {
+      expect(entry.artifacts.linksNotation).toContain('term-data-request');
+      expect(decodeFromDoublets(entry.artifacts.binary).request.url).toContain(
+        'https://'
+      );
+    }
+
+    const callCount = calls.length;
+    const second = await source.getTerm('apple');
+    expect(calls.length).toBe(callCount);
+    expect(second.fields).toEqual(first.fields);
+    expect(second.artifacts.linksNotation).toBe(first.artifacts.linksNotation);
+  });
+
+  it('caches repeated top-level getTerm calls', async () => {
+    const calls = [];
+    const options = {
+      cacheJitterMs: 0,
+      cacheTtlMs: 1000,
+      fetch: makeFetch(calls),
+      now: () => 0,
+    };
+
+    await getTerm('issue108 cache probe', options);
+    const callCount = calls.length;
+    const second = await getTerm('issue108 cache probe', options);
+
+    expect(calls.length).toBe(callCount);
+    expect(second.fields.id).toBe('Q89');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #108.

Adds a unified, on-demand Wikimedia term data source for a single term:

- `createTermDataSource()` / `getTerm()` resolve Wikidata structured data, Wikipedia summary text, and Wiktionary lexical entries through one API.
- The merged record carries per-field provenance with source, source field, target field, merge strategy, source URL, and retrieval time.
- Raw Wikimedia request/response cache entries and the merged term record both get Links Notation and binary doublets artifacts.
- Public exports and type declarations include `createTermDataSource`, `getTerm`, and `parseTermDataLinksNotation`.
- Adds a changeset for the new public API.

## Reproduction And Verification

The new unit test builds a mocked Apple term lookup and verifies:

- Wikidata/Wikipedia/Wiktionary contributions appear in the merged record.
- Field-level provenance identifies which source contributed each merged field.
- Raw request cache entries contain Links Notation and binary artifacts.
- The merged record round-trips through Links Notation and binary doublets.
- Repeated `getTerm()` calls hit cache without refetching.

## Testing

```bash
npm test
npm run check
```

Latest local results:

- `npm test`: unit 56/56, integration 257 passed + 10 skipped, e2e 80/80.
- `npm run check`: lint, format, duplication, and formalize docs checks passed.
