### PR TITLE
feat: Adopt doublets-web as the browser meta-language store

### DIFF
--- a/.changeset/issue-110-doublets-web-browser-store.md
+++ b/.changeset/issue-110-doublets-web-browser-store.md
@@ -1,0 +1,5 @@
+---
+'meta-expression': minor
+---
+
+Adopt doublets-web as the browser-side doublets store for meta-language persistence and web cache serialization.

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -381,11 +381,14 @@ jobs:
         run: |
           mkdir -p _site
           mkdir -p _site/js
+          mkdir -p _site/node_modules/doublets-web
           mkdir -p _site/node_modules/links-notation
           mkdir -p _site/rust
           cp -R web _site/
           cp -R js/src _site/js/
           cp -R js/data _site/js/
+          cp -R node_modules/doublets-web/doublets_web* _site/node_modules/doublets-web/
+          cp node_modules/doublets-web/package.json _site/node_modules/doublets-web/
           cp -R node_modules/links-notation/dist _site/node_modules/links-notation/
           cp -R rust/pkg _site/rust/
           node --input-type=module <<'NODE'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-26T20:53:19.738Z for PR creation at branch issue-110-9276996a2025 for issue https://github.com/link-assistant/meta-expression/issues/110

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T20:53:19.738Z for PR creation at branch issue-110-9276996a2025 for issue https://github.com/link-assistant/meta-expression/issues/110

--- a/js/src/browser-doublets-web.js
+++ b/js/src/browser-doublets-web.js
@@ -1,0 +1,182 @@
+import * as doubletsWebBindings from '../../node_modules/doublets-web/doublets_web_bg.js';
+import {
+  createDoubletValueStore,
+  deserializeDoubletLinks,
+} from './doublets.js';
+import {
+  exportPortableCaseData,
+  importPortableCaseData,
+} from './durable-storage.js';
+
+const portableCaseSchema = 'meta-expression.portable-case';
+const portableCaseVersion = 1;
+const defaultWasmUrl = new URL(
+  '../../node_modules/doublets-web/doublets_web_bg.wasm',
+  import.meta.url
+);
+
+let bindingPromise = null;
+
+export async function loadDoubletsWeb(options = {}) {
+  if (!bindingPromise) {
+    bindingPromise = instantiateDoubletsWeb(options.wasmUrl ?? defaultWasmUrl);
+  }
+  try {
+    await bindingPromise;
+  } catch (error) {
+    bindingPromise = null;
+    throw error;
+  }
+  return doubletsWebBindings;
+}
+
+export async function createDoubletsWebStore(options = {}) {
+  const bindings = await loadDoubletsWeb(options);
+  return createDoubletValueStore(createDoubletsWebLinkStore(bindings));
+}
+
+export async function encodeAsDoubletsWeb(value, options = {}) {
+  const store = await createDoubletsWebStore(options);
+  const rootIndex = store.storeValue(value);
+  return { binary: store.serialize(), rootIndex, store };
+}
+
+export async function decodeFromDoubletsWeb(binary, rootIndex, options = {}) {
+  const store = await createDoubletsWebStore(options);
+  store.restore(binary);
+  return store.readValue(rootIndex ?? store.size());
+}
+
+export async function savePortableCaseToDoubletsWeb(input, options = {}) {
+  const portable = exportPortableCaseData(input, options);
+  portable.storage = {
+    ...portable.storage,
+    implementation: 'doublets-web',
+  };
+  const { binary, rootIndex, store } = await encodeAsDoubletsWeb(
+    portable,
+    options
+  );
+
+  return {
+    format: portableCaseSchema,
+    version: portableCaseVersion,
+    binary,
+    rootIndex,
+    linksNotation: store.toLinksNotation(),
+    portable,
+  };
+}
+
+export async function loadPortableCaseFromDoubletsWeb(input, options = {}) {
+  const binary = input instanceof Uint8Array ? input : input?.binary;
+  if (!(binary instanceof Uint8Array)) {
+    throw new TypeError(
+      'Portable Doublets input must include Uint8Array bytes.'
+    );
+  }
+  const decoded = await decodeFromDoubletsWeb(
+    binary,
+    input?.rootIndex,
+    options
+  );
+  return importPortableCaseData(decoded);
+}
+
+async function instantiateDoubletsWeb(wasmUrl) {
+  const imports = { './doublets_web_bg.js': doubletsWebBindings };
+  const response = await fetch(wasmUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load doublets-web WASM: HTTP ${response.status}`
+    );
+  }
+  const { instance } = await instantiateWasm(response, imports);
+  doubletsWebBindings.__wbg_set_wasm(instance.exports);
+  instance.exports.__wbindgen_start?.();
+}
+
+async function instantiateWasm(response, imports) {
+  const contentType = response.headers.get('content-type') ?? '';
+  const webAssembly = globalThis.WebAssembly;
+  if (webAssembly.instantiateStreaming && contentType.includes('wasm')) {
+    return webAssembly.instantiateStreaming(response, imports);
+  }
+  const bytes = await response.arrayBuffer();
+  return webAssembly.instantiate(bytes, imports);
+}
+
+function createDoubletsWebLinkStore(bindings) {
+  let links = new bindings.UnitedLinks();
+  let constants = links.constants;
+  let snapshot = null;
+
+  function create(source, target) {
+    const index = links.create();
+    links.update(index, source >>> 0, target >>> 0);
+    snapshot = null;
+    return index;
+  }
+
+  function each() {
+    return [...snapshotLinks().values()].filter((link) => link.index !== 0);
+  }
+
+  function get(index) {
+    return snapshotLinks().get(index);
+  }
+
+  function size() {
+    return links.count();
+  }
+
+  function restore(binary) {
+    reset();
+    const records = deserializeDoubletLinks(binary)
+      .filter((link) => link.index !== 0)
+      .sort((left, right) => left.index - right.index);
+    for (const record of records) {
+      const index = links.create();
+      if (index !== record.index) {
+        throw new Error(
+          `doublets-web restore expected link ${record.index}, created ${index}`
+        );
+      }
+      links.update(index, record.source >>> 0, record.target >>> 0);
+    }
+    snapshot = null;
+  }
+
+  function reset() {
+    links = new bindings.UnitedLinks();
+    constants = links.constants;
+    snapshot = null;
+  }
+
+  function snapshotLinks() {
+    if (snapshot) {
+      return snapshot;
+    }
+    const next = new Map([[0, { index: 0, source: 0, target: 0 }]]);
+    const continuation = constants._continue;
+    links.each((link) => {
+      next.set(link.id, {
+        index: link.id,
+        source: link.from_id,
+        target: link.to_id,
+      });
+      return continuation;
+    });
+    snapshot = next;
+    return snapshot;
+  }
+
+  return {
+    create,
+    each,
+    get,
+    size,
+    restore,
+    reset,
+  };
+}

--- a/js/src/doublets.js
+++ b/js/src/doublets.js
@@ -48,25 +48,26 @@ const OBJECT_TAG = 0x50000000;
  *   reset: () => void,
  * }}
  */
-// eslint-disable-next-line max-lines-per-function
+// Public wrapper around the default in-memory link store.
 export function createDoubletStore() {
-  /** @type {Doublet[]} */
-  let links = [{ index: NULL_LINK, source: NULL_LINK, target: NULL_LINK }];
+  return createDoubletValueStore(createMemoryDoubletLinkStore());
+}
+
+// eslint-disable-next-line max-lines-per-function
+export function createDoubletValueStore(linkStore) {
   /** @type {Map<string, number>} */
   let stringIndex = new Map();
 
   function create(source, target) {
-    const index = links.length;
-    links.push({ index, source, target });
-    return index;
+    return linkStore.create(source, target);
   }
 
   function each() {
-    return links.slice(1);
+    return linkStore.each();
   }
 
   function size() {
-    return links.length - 1;
+    return linkStore.size();
   }
 
   function storeCodePoint(codePoint) {
@@ -95,18 +96,18 @@ export function createDoubletStore() {
   }
 
   function readString(rootIndex) {
-    const root = links[rootIndex];
+    const root = linkStore.get(rootIndex);
     if (!root || root.source !== STRING_TAG) {
       return '';
     }
     const codes = [];
     let cursor = root.target;
     while (cursor !== NULL_LINK) {
-      const link = links[cursor];
+      const link = linkStore.get(cursor);
       if (!link) {
         break;
       }
-      const point = links[link.target];
+      const point = linkStore.get(link.target);
       if (!point || point.source !== STRING_TAG) {
         break;
       }
@@ -161,7 +162,7 @@ export function createDoubletStore() {
 
   // eslint-disable-next-line complexity
   function readValue(rootIndex) {
-    const root = links[rootIndex];
+    const root = linkStore.get(rootIndex);
     if (!root) {
       return null;
     }
@@ -178,7 +179,7 @@ export function createDoubletStore() {
       const items = [];
       let cursor = root.target;
       while (cursor !== NULL_LINK) {
-        const link = links[cursor];
+        const link = linkStore.get(cursor);
         if (!link) {
           break;
         }
@@ -192,11 +193,11 @@ export function createDoubletStore() {
       const entries = [];
       let cursor = root.target;
       while (cursor !== NULL_LINK) {
-        const link = links[cursor];
+        const link = linkStore.get(cursor);
         if (!link) {
           break;
         }
-        const pair = links[link.target];
+        const pair = linkStore.get(link.target);
         if (!pair) {
           break;
         }
@@ -211,11 +212,11 @@ export function createDoubletStore() {
       return out;
     }
     if (root.source === NUMBER_TAG) {
-      const loLink = links[root.target];
+      const loLink = linkStore.get(root.target);
       if (!loLink) {
         return 0;
       }
-      const hiLink = links[loLink.source];
+      const hiLink = linkStore.get(loLink.source);
       const lo = loLink.target >>> 0;
       const hi = hiLink ? hiLink.target >>> 0 : 0;
       const view = new DataView(new ArrayBuffer(8));
@@ -227,49 +228,20 @@ export function createDoubletStore() {
   }
 
   function serialize() {
-    const buffer = new ArrayBuffer(links.length * 12);
-    const view = new DataView(buffer);
-    for (let i = 0; i < links.length; i += 1) {
-      const link = links[i];
-      view.setUint32(i * 12, link.index >>> 0, true);
-      view.setUint32(i * 12 + 4, link.source >>> 0, true);
-      view.setUint32(i * 12 + 8, link.target >>> 0, true);
-    }
-    return new Uint8Array(buffer);
+    return serializeDoubletLinks(linkStore.each());
   }
 
   function restore(binary) {
-    const buffer =
-      binary.buffer.byteLength === binary.byteLength
-        ? binary.buffer
-        : binary.slice().buffer;
-    const view = new DataView(buffer);
-    const total = Math.floor(view.byteLength / 12);
-    links = [];
+    linkStore.restore(binary);
     stringIndex = new Map();
-    for (let i = 0; i < total; i += 1) {
-      links.push({
-        index: view.getUint32(i * 12, true),
-        source: view.getUint32(i * 12 + 4, true),
-        target: view.getUint32(i * 12 + 8, true),
-      });
-    }
-    if (links.length === 0) {
-      links.push({ index: NULL_LINK, source: NULL_LINK, target: NULL_LINK });
-    }
   }
 
   function toLinksNotation() {
-    const lines = [`(doublets: ${links.length - 1})`];
-    for (let i = 1; i < links.length; i += 1) {
-      const link = links[i];
-      lines.push(`(${link.index}: ${link.source} ${link.target})`);
-    }
-    return lines.join('\n');
+    return doubletLinksToLinksNotation(linkStore.each());
   }
 
   function reset() {
-    links = [{ index: NULL_LINK, source: NULL_LINK, target: NULL_LINK }];
+    linkStore.reset();
     stringIndex = new Map();
   }
 
@@ -286,6 +258,92 @@ export function createDoubletStore() {
     toLinksNotation,
     reset,
   };
+}
+
+function createMemoryDoubletLinkStore() {
+  /** @type {Doublet[]} */
+  let links = [{ index: NULL_LINK, source: NULL_LINK, target: NULL_LINK }];
+
+  function create(source, target) {
+    const index = links.length;
+    links.push({ index, source: source >>> 0, target: target >>> 0 });
+    return index;
+  }
+
+  function each() {
+    return links.slice(1);
+  }
+
+  function get(index) {
+    return links[index];
+  }
+
+  function size() {
+    return links.length - 1;
+  }
+
+  function restore(binary) {
+    links = deserializeDoubletLinks(binary);
+  }
+
+  function reset() {
+    links = [{ index: NULL_LINK, source: NULL_LINK, target: NULL_LINK }];
+  }
+
+  return {
+    create,
+    each,
+    get,
+    size,
+    restore,
+    reset,
+  };
+}
+
+export function deserializeDoubletLinks(binary) {
+  const bytes = binary instanceof Uint8Array ? binary : new Uint8Array(binary);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const total = Math.floor(view.byteLength / 12);
+  const links = [];
+  for (let i = 0; i < total; i += 1) {
+    links.push({
+      index: view.getUint32(i * 12, true),
+      source: view.getUint32(i * 12 + 4, true),
+      target: view.getUint32(i * 12 + 8, true),
+    });
+  }
+  if (links.length === 0) {
+    links.push({ index: NULL_LINK, source: NULL_LINK, target: NULL_LINK });
+  }
+  return links;
+}
+
+function serializeDoubletLinks(links) {
+  const maxIndex = links.reduce(
+    (max, link) => Math.max(max, Number(link.index) || 0),
+    NULL_LINK
+  );
+  const buffer = new ArrayBuffer((maxIndex + 1) * 12);
+  const view = new DataView(buffer);
+  view.setUint32(0, NULL_LINK, true);
+  view.setUint32(4, NULL_LINK, true);
+  view.setUint32(8, NULL_LINK, true);
+  for (const link of links) {
+    const offset = link.index * 12;
+    view.setUint32(offset, link.index >>> 0, true);
+    view.setUint32(offset + 4, link.source >>> 0, true);
+    view.setUint32(offset + 8, link.target >>> 0, true);
+  }
+  return new Uint8Array(buffer);
+}
+
+function doubletLinksToLinksNotation(links) {
+  const sorted = [...links].sort((left, right) => left.index - right.index);
+  const lines = [`(doublets: ${sorted.length})`];
+  for (const link of sorted) {
+    lines.push(`(${link.index}: ${link.source} ${link.target})`);
+  }
+  return lines.join('\n');
 }
 
 /**

--- a/js/tests/e2e/issue-110.test.js
+++ b/js/tests/e2e/issue-110.test.js
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'test-anywhere';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, relative, resolve } from 'node:path';
+import { verifyWebModuleGraph } from '../../../scripts/verify-web-module-graph.mjs';
+
+describe('issue 110 - doublets-web browser store', () => {
+  it('keeps the doublets-web browser store in the static module graph', async () => {
+    const result = await verifyWebModuleGraph({
+      root: new URL('../../../', import.meta.url),
+      entries: ['../js/src/browser-doublets-web.js'],
+    });
+
+    expect(result.invalidImports).toEqual([]);
+    expect(result.contentTypeProblems).toEqual([]);
+    expect(
+      result.modules.some((moduleUrl) =>
+        moduleUrl.endsWith('/node_modules/doublets-web/doublets_web_bg.js')
+      )
+    ).toBe(true);
+    expect(
+      result.modules.some((moduleUrl) =>
+        moduleUrl.endsWith('/node_modules/doublets-web/doublets_web_bg.wasm')
+      )
+    ).toBe(true);
+  });
+
+  it('stores and loads portable meta-language links in a browser', async () => {
+    const playwright = await tryLoadPlaywright();
+    if (!playwright) {
+      return;
+    }
+    const server = await startStaticServer(resolve('.'));
+    let browser = null;
+    try {
+      browser = await playwright.chromium.launch();
+    } catch (error) {
+      if (isMissingBrowserError(error)) {
+        return;
+      }
+      throw error;
+    }
+    try {
+      const page = await browser.newPage();
+      await page.goto(`${server.origin}/web/`);
+      const result = await page.evaluate(async () => {
+        const {
+          decodeFromDoubletsWeb,
+          encodeAsDoubletsWeb,
+          loadPortableCaseFromDoubletsWeb,
+          savePortableCaseToDoubletsWeb,
+        } = await import('../js/src/browser-doublets-web.js');
+        const linksNetwork = {
+          id: 'issue-110-browser',
+          kind: 'links-network',
+          version: 1,
+          beliefSystem: {
+            id: 'test',
+            name: 'Test',
+            probabilityStrategy: 'weighted-support-ratio',
+            sourceWeights: {},
+          },
+          links: [
+            {
+              id: 'statement-1',
+              role: 'statement',
+              references: [],
+              version: 1,
+              value: { text: 'Doublets-web stores browser links.' },
+              provenance: {
+                sourceType: 'test',
+                method: 'playwright-smoke',
+                sourceUrl: null,
+                retrievedAt: '2026-05-26T00:00:00.000Z',
+              },
+            },
+          ],
+        };
+        const saved = await savePortableCaseToDoubletsWeb(
+          { linksNetwork },
+          {
+            caseId: 'issue-110-browser',
+            exportedAt: '2026-05-26T00:00:00.000Z',
+          }
+        );
+        const loaded = await loadPortableCaseFromDoubletsWeb(saved);
+        const cacheSnapshot = [
+          ['Q42', { label: 'Douglas Adams', source: 'wikidata' }],
+        ];
+        const cached = await encodeAsDoubletsWeb(cacheSnapshot);
+        const decodedCache = await decodeFromDoubletsWeb(cached.binary);
+        return {
+          bytes: saved.binary.byteLength,
+          cacheLabel: decodedCache[0][1].label,
+          implementation: saved.portable.storage.implementation,
+          text: loaded.linksNetwork.links[0].value.text,
+        };
+      });
+
+      expect(result.bytes).toBeGreaterThan(0);
+      expect(result.cacheLabel).toBe('Douglas Adams');
+      expect(result.implementation).toBe('doublets-web');
+      expect(result.text).toBe('Doublets-web stores browser links.');
+    } finally {
+      await browser?.close();
+      await server.close();
+    }
+  });
+});
+
+async function tryLoadPlaywright() {
+  try {
+    return await import('playwright');
+  } catch {
+    return null;
+  }
+}
+
+function isMissingBrowserError(error) {
+  return /Executable doesn't exist|browserType\.launch/u.test(
+    error instanceof Error ? error.message : String(error)
+  );
+}
+
+function startStaticServer(root) {
+  const server = createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+      const filePath = resolvePath(root, url.pathname);
+      const body = await readFile(filePath);
+      response.writeHead(200, {
+        'content-type': contentType(filePath),
+      });
+      response.end(body);
+    } catch {
+      response.writeHead(404, { 'content-type': 'text/plain' });
+      response.end('not found');
+    }
+  });
+  return new Promise((resolveServer, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolveServer({
+        origin: `http://127.0.0.1:${port}`,
+        close: () => new Promise((resolveClose) => server.close(resolveClose)),
+      });
+    });
+  });
+}
+
+function resolvePath(root, pathname) {
+  const requested = pathname.endsWith('/') ? `${pathname}index.html` : pathname;
+  const filePath = join(root, normalize(decodeURIComponent(requested)));
+  if (relative(root, filePath).startsWith('..')) {
+    throw new Error('Path escapes static root.');
+  }
+  return filePath;
+}
+
+function contentType(path) {
+  const extension = extname(path);
+  if (extension === '.html') {
+    return 'text/html';
+  }
+  if (extension === '.js') {
+    return 'text/javascript';
+  }
+  if (extension === '.json') {
+    return 'application/json';
+  }
+  if (extension === '.wasm') {
+    return 'application/wasm';
+  }
+  return 'application/octet-stream';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.0",
       "license": "Unlicense",
       "dependencies": {
+        "doublets-web": "^0.1.3",
         "links-notation": "^0.13.0",
         "lino-arguments": "^0.3.0"
       },
@@ -23,6 +24,7 @@
         "husky": "^9.1.7",
         "jscpd": "^4.0.5",
         "lint-staged": "^16.2.6",
+        "playwright": "^1.60.0",
         "prettier": "^3.6.2",
         "test-anywhere": "^0.8.48",
         "wasm-pack": "^0.15.0"
@@ -1466,6 +1468,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/doublets-web": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/doublets-web/-/doublets-web-0.1.3.tgz",
+      "integrity": "sha512-8HVF+X/qSzacm947mKi5gw3aa2V0GOpbwMZXxFDROc4k1PVPOVwMR7b3PfiZND2E2k6lxXUk5BlIWHxLbsx/+A==",
+      "license": "Unlicense"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2063,6 +2071,21 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -3362,6 +3385,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "husky": "^9.1.7",
     "jscpd": "^4.0.5",
     "lint-staged": "^16.2.6",
+    "playwright": "^1.60.0",
     "prettier": "^3.6.2",
     "test-anywhere": "^0.8.48",
     "wasm-pack": "^0.15.0"
@@ -88,6 +89,7 @@
     ]
   },
   "dependencies": {
+    "doublets-web": "^0.1.3",
     "links-notation": "^0.13.0",
     "lino-arguments": "^0.3.0"
   },

--- a/scripts/verify-web-module-graph.mjs
+++ b/scripts/verify-web-module-graph.mjs
@@ -40,17 +40,16 @@ export async function verifyWebModuleGraph(options = {}) {
     if (loaded.contentTypeProblem) {
       contentTypeProblems.push(loaded.contentTypeProblem);
     }
-    if (moduleUrl.pathname.endsWith('.json')) {
+    if (
+      moduleUrl.pathname.endsWith('.json') ||
+      moduleUrl.pathname.endsWith('.wasm')
+    ) {
       continue;
     }
     const imports = parseStaticImports(loaded.text);
     const workerEntries = parseModuleWorkerEntries(loaded.text);
     const resourceEntries = parseImportMetaResourceEntries(loaded.text);
-    for (const specifier of [
-      ...imports,
-      ...workerEntries,
-      ...resourceEntries,
-    ]) {
+    for (const specifier of [...imports, ...workerEntries]) {
       const resolvedImport = resolveBrowserImport(
         specifier,
         moduleUrl,
@@ -65,6 +64,9 @@ export async function verifyWebModuleGraph(options = {}) {
           reason: resolvedImport.reason,
         });
       }
+    }
+    for (const resource of resourceEntries) {
+      pending.push(new URL(resource, moduleUrl).href);
     }
   }
 
@@ -153,7 +155,7 @@ function parseModuleWorkerEntries(source) {
 function parseImportMetaResourceEntries(source) {
   const entries = [];
   const pattern =
-    /\bnew\s+URL\s*\(\s*["']([^"']+\.(?:json|js))["']\s*,\s*import\.meta\.url\s*\)/gu;
+    /\bnew\s+URL\s*\(\s*["']([^"']+\.(?:json|js|wasm))["']\s*,\s*import\.meta\.url\s*\)/gu;
   for (const match of source.matchAll(pattern)) {
     entries.push(match[1]);
   }
@@ -249,6 +251,13 @@ function contentTypeProblem(url, contentType) {
       url: url.href,
       contentType,
       expected: 'application/json',
+    };
+  }
+  if (url.pathname.endsWith('.wasm') && normalized !== 'application/wasm') {
+    return {
+      url: url.href,
+      contentType,
+      expected: 'application/wasm',
     };
   }
   return null;

--- a/web/app.js
+++ b/web/app.js
@@ -47,6 +47,7 @@ import {
   summary,
 } from './format-helpers.js';
 import { createPersistentWikimediaCache } from './persistent-cache.js';
+import { createBrowserMetaLanguageStore } from './meta-language-store.js';
 import {
   getActivePreferenceProfile,
   setupPreferencesPage,
@@ -63,7 +64,8 @@ import {
 } from './source-priority-ui.js';
 
 const beliefStorageKey = 'meta-expression.user-beliefs.v1';
-const wikimediaCacheStorageKey = 'meta-expression.wikimedia-cache.v1';
+const wikimediaCacheStorageKey = 'meta-expression.wikimedia-cache.v2';
+const metaLanguageStorageKey = 'meta-expression.meta-language-store.v1';
 const defaultRandomExampleCount = 4;
 const topInterpretationCount = 10;
 
@@ -130,6 +132,11 @@ let randomSeed = Date.now();
 let strategyId = defaultReasoningStrategyId;
 const userBeliefs = loadUserBeliefs();
 const wikimediaCache = createPersistentWikimediaCache(wikimediaCacheStorageKey);
+const metaLanguageStore = createBrowserMetaLanguageStore(
+  metaLanguageStorageKey
+);
+void wikimediaCache.ready;
+void metaLanguageStore.load();
 const liveEvidenceWorker = createLiveEvidenceWorker();
 const liveEvidenceClientFallback = liveEvidenceWorker
   ? null
@@ -219,6 +226,7 @@ function render(statement, interpretationIndex = 0) {
     preferenceProfile: getActivePreferenceProfile(),
     reasoningStrategyId: strategyId,
   });
+  persistMetaLanguageCase(currentAnalysis, 'analysis-current');
 
   renderInterpretations(draft);
   renderAlternatives(currentAnalysis.alternatives);
@@ -232,6 +240,15 @@ function render(statement, interpretationIndex = 0) {
   syncSelectedExample(statement);
   requestLiveEvidence(statement);
   linoOutput.hidden = true;
+}
+
+function persistMetaLanguageCase(input, caseId) {
+  void metaLanguageStore
+    .save(input, {
+      caseId,
+      exportedAt: new Date().toISOString(),
+    })
+    .catch(() => {});
 }
 
 function renderInterpretations(draft) {
@@ -519,6 +536,7 @@ function applyLiveEvidenceResult(data) {
     evidence: data.evidence,
     reasoningStrategyId: strategyId,
   });
+  persistMetaLanguageCase(currentAnalysis, 'analysis-live-evidence');
   renderConfirmations(currentAnalysis.confirmations);
   renderRefutations(currentAnalysis.refutations);
   renderResult(currentAnalysis);
@@ -1159,6 +1177,7 @@ function applyFormalizeResult(data) {
     return;
   }
   currentFormalizeResult = result;
+  persistMetaLanguageCase(result.linksNetwork, 'formalize-current');
   activeInterpretationKey = null;
   renderFormalizeOutput(result);
   renderFormalizeContexts(result);

--- a/web/evidence-worker.js
+++ b/web/evidence-worker.js
@@ -1,9 +1,14 @@
 import { createWikimediaEvidenceClient } from '../js/src/index.js';
+import {
+  decodeFromDoubletsWeb,
+  encodeAsDoubletsWeb,
+} from '../js/src/browser-doublets-web.js';
 
-const wikimediaCacheStorageKey = 'meta-expression.wikimedia-cache.v1';
+const wikimediaCacheStorageKey = 'meta-expression.wikimedia-cache.v2';
+const legacyCacheStorageKey = 'meta-expression.wikimedia-cache.v1';
 const cache = new Map();
 
-hydrateCache();
+const cacheReady = hydrateCache();
 
 const client = createWikimediaEvidenceClient({ cache });
 
@@ -14,8 +19,9 @@ self.addEventListener('message', async (event) => {
   }
 
   try {
+    await cacheReady;
     const evidence = await client.resolveEvidence(statement);
-    persistCache();
+    await persistCache();
     self.postMessage({ id, evidence });
   } catch (error) {
     self.postMessage({
@@ -25,38 +31,68 @@ self.addEventListener('message', async (event) => {
   }
 });
 
-function hydrateCache() {
+async function hydrateCache() {
   if (typeof self.localStorage === 'undefined') {
     return;
   }
   try {
     const raw = self.localStorage.getItem(wikimediaCacheStorageKey);
-    if (!raw) {
-      return;
+    if (raw) {
+      try {
+        const entries = await decodeFromDoubletsWeb(decodeBase64ToBytes(raw));
+        if (Array.isArray(entries)) {
+          for (const [key, value] of entries) {
+            cache.set(key, value);
+          }
+          return;
+        }
+      } catch {
+        // Try the previous JSON cache below if the new binary cache is stale.
+      }
     }
-    const entries = JSON.parse(raw);
-    if (!Array.isArray(entries)) {
-      return;
-    }
-    for (const [key, value] of entries) {
-      cache.set(key, value);
+    const legacy = self.localStorage.getItem(legacyCacheStorageKey);
+    if (legacy) {
+      const entries = JSON.parse(legacy);
+      if (Array.isArray(entries)) {
+        for (const [key, value] of entries) {
+          cache.set(key, value);
+        }
+      }
     }
   } catch {
     // Best effort hydration.
   }
 }
 
-function persistCache() {
+async function persistCache() {
   if (typeof self.localStorage === 'undefined') {
     return;
   }
   try {
     const entries = [...cache.entries()].slice(-200);
+    const { binary } = await encodeAsDoubletsWeb(entries);
     self.localStorage.setItem(
       wikimediaCacheStorageKey,
-      JSON.stringify(entries)
+      encodeBytesToBase64(binary)
     );
   } catch {
     // Best effort persistence.
   }
+}
+
+function encodeBytesToBase64(bytes) {
+  let binaryString = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binaryString += String.fromCharCode(bytes[i]);
+  }
+  return self.btoa(binaryString);
+}
+
+function decodeBase64ToBytes(text) {
+  const binaryString = self.atob(text);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i += 1) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
 }

--- a/web/formalize-worker.js
+++ b/web/formalize-worker.js
@@ -1,10 +1,12 @@
 import {
-  decodeFromDoublets,
-  encodeAsDoublets,
   formalizeTextWith,
   parseSourceSpec,
   createWikidataSource,
 } from '../js/src/index.js';
+import {
+  decodeFromDoubletsWeb,
+  encodeAsDoubletsWeb,
+} from '../js/src/browser-doublets-web.js';
 
 // v2: cache entries are stored as base64-encoded doublets blobs. The
 // previous v1 key held a JSON snapshot — we leave it for one release so
@@ -13,7 +15,7 @@ const wikimediaCacheStorageKey = 'meta-expression.wikimedia-cache.v2';
 const legacyCacheStorageKey = 'meta-expression.wikimedia-cache.v1';
 const cache = new Map();
 
-hydrateCache();
+const cacheReady = hydrateCache();
 
 self.addEventListener('message', async (event) => {
   const { id, text, options } = event.data ?? {};
@@ -22,13 +24,14 @@ self.addEventListener('message', async (event) => {
   }
 
   try {
+    await cacheReady;
     const finalOptions = resolveOptions(options ?? {});
     const result = await formalizeTextWith(text, {
       ...finalOptions,
       cache,
       fetch: self.fetch?.bind(self),
     });
-    persistCache();
+    await persistCache();
     self.postMessage({ id, result: serializeResult(result) });
   } catch (error) {
     self.postMessage({
@@ -74,20 +77,24 @@ function serializeResult(result) {
   };
 }
 
-function hydrateCache() {
+async function hydrateCache() {
   if (typeof self.localStorage === 'undefined') {
     return;
   }
   try {
     const raw = self.localStorage.getItem(wikimediaCacheStorageKey);
     if (raw) {
-      const decoded = decodeBase64ToBytes(raw);
-      const entries = decodeFromDoublets(decoded);
-      if (Array.isArray(entries)) {
-        for (const [key, value] of entries) {
-          cache.set(key, value);
+      try {
+        const decoded = decodeBase64ToBytes(raw);
+        const entries = await decodeFromDoubletsWeb(decoded);
+        if (Array.isArray(entries)) {
+          for (const [key, value] of entries) {
+            cache.set(key, value);
+          }
+          return;
         }
-        return;
+      } catch {
+        // Try the previous JSON cache below if the new binary cache is stale.
       }
     }
     const legacy = self.localStorage.getItem(legacyCacheStorageKey);
@@ -104,13 +111,13 @@ function hydrateCache() {
   }
 }
 
-function persistCache() {
+async function persistCache() {
   if (typeof self.localStorage === 'undefined') {
     return;
   }
   try {
     const entries = [...cache.entries()].slice(-200);
-    const { binary } = encodeAsDoublets(entries);
+    const { binary } = await encodeAsDoubletsWeb(entries);
     self.localStorage.setItem(
       wikimediaCacheStorageKey,
       encodeBytesToBase64(binary)

--- a/web/meta-language-store.js
+++ b/web/meta-language-store.js
@@ -1,0 +1,61 @@
+import {
+  loadPortableCaseFromDoubletsWeb,
+  savePortableCaseToDoubletsWeb,
+} from '../js/src/browser-doublets-web.js';
+
+export function createBrowserMetaLanguageStore(storageKey) {
+  return {
+    async load() {
+      try {
+        const raw = globalThis.localStorage?.getItem(storageKey);
+        if (!raw) {
+          return null;
+        }
+        const record = JSON.parse(raw);
+        const binary = decodeBase64ToBytes(record.binary);
+        return await loadPortableCaseFromDoubletsWeb({
+          binary,
+          rootIndex: record.rootIndex,
+        });
+      } catch {
+        return null;
+      }
+    },
+
+    async save(input, options = {}) {
+      const saved = await savePortableCaseToDoubletsWeb(input, options);
+      try {
+        globalThis.localStorage?.setItem(
+          storageKey,
+          JSON.stringify({
+            format: saved.format,
+            version: saved.version,
+            rootIndex: saved.rootIndex,
+            binary: encodeBytesToBase64(saved.binary),
+            savedAt: options.exportedAt ?? new Date().toISOString(),
+          })
+        );
+      } catch {
+        // Browser persistence is best effort; callers still receive the store.
+      }
+      return saved;
+    },
+  };
+}
+
+export function encodeBytesToBase64(bytes) {
+  let binaryString = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binaryString += String.fromCharCode(bytes[i]);
+  }
+  return globalThis.btoa(binaryString);
+}
+
+export function decodeBase64ToBytes(text) {
+  const binaryString = globalThis.atob(text);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i += 1) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/web/persistent-cache.js
+++ b/web/persistent-cache.js
@@ -1,49 +1,93 @@
+import {
+  decodeBase64ToBytes,
+  encodeBytesToBase64,
+} from './meta-language-store.js';
+import {
+  decodeFromDoubletsWeb,
+  encodeAsDoubletsWeb,
+} from '../js/src/browser-doublets-web.js';
+
 export function createPersistentWikimediaCache(storageKey) {
   const map = new Map();
-  hydrateWikimediaCache(map, storageKey);
+  const legacyStorageKey = storageKey.replace(/\.v2$/u, '.v1');
+  const writeEntry = Map.prototype.set.bind(map);
+  const ready = hydrateWikimediaCache(writeEntry, storageKey, legacyStorageKey);
+  let pendingPersist = ready;
+  Object.defineProperty(map, 'ready', {
+    value: ready,
+    enumerable: false,
+  });
   const originalSet = map.set.bind(map);
   map.set = (key, value) => {
     const result = originalSet(key, value);
-    persistWikimediaCache(map, storageKey);
+    pendingPersist = schedulePersist(pendingPersist, map, storageKey);
     return result;
   };
   const originalDelete = map.delete.bind(map);
   map.delete = (key) => {
     const result = originalDelete(key);
-    persistWikimediaCache(map, storageKey);
+    pendingPersist = schedulePersist(pendingPersist, map, storageKey);
     return result;
   };
   const originalClear = map.clear.bind(map);
   map.clear = () => {
     originalClear();
-    persistWikimediaCache(map, storageKey);
+    pendingPersist = schedulePersist(pendingPersist, map, storageKey);
   };
   return map;
 }
 
-function hydrateWikimediaCache(map, storageKey) {
+async function hydrateWikimediaCache(writeEntry, storageKey, legacyStorageKey) {
   try {
     const raw = globalThis.localStorage.getItem(storageKey);
-    if (!raw) {
-      return;
+    if (raw) {
+      try {
+        const entries = await decodeFromDoubletsWeb(decodeCacheBytes(raw));
+        if (Array.isArray(entries)) {
+          for (const [key, value] of entries) {
+            writeEntry(key, value);
+          }
+          return;
+        }
+      } catch {
+        // Try the previous JSON cache below if the new binary cache is stale.
+      }
     }
-    const entries = JSON.parse(raw);
-    if (!Array.isArray(entries)) {
-      return;
-    }
-    for (const [key, value] of entries) {
-      map.set(key, value);
+    const legacy = globalThis.localStorage.getItem(legacyStorageKey);
+    if (legacy) {
+      const entries = JSON.parse(legacy);
+      if (Array.isArray(entries)) {
+        for (const [key, value] of entries) {
+          writeEntry(key, value);
+        }
+      }
     }
   } catch {
     // Cache is best-effort and survives storage problems silently.
   }
 }
 
-function persistWikimediaCache(map, storageKey) {
+function schedulePersist(pendingPersist, map, storageKey) {
+  return pendingPersist
+    .catch(() => {})
+    .then(() => persistWikimediaCache(map, storageKey));
+}
+
+async function persistWikimediaCache(map, storageKey) {
   try {
     const entries = [...map.entries()].slice(-200);
-    globalThis.localStorage.setItem(storageKey, JSON.stringify(entries));
+    const { binary } = await encodeAsDoubletsWeb(entries);
+    globalThis.localStorage.setItem(storageKey, encodeBytesToBase64(binary));
   } catch {
     // Storage may be unavailable; the in-memory cache still works for this page.
   }
+}
+
+function decodeCacheBytes(raw) {
+  const text = String(raw).trim();
+  if (text.startsWith('{')) {
+    const record = JSON.parse(text);
+    return decodeBase64ToBytes(record.binary);
+  }
+  return decodeBase64ToBytes(text);
 }

--- a/web/translate-ui.js
+++ b/web/translate-ui.js
@@ -13,7 +13,7 @@ import {
 } from './source-priority-ui.js';
 import { translateSamples } from './translate-samples.js';
 
-const translateCacheStorageKey = 'meta-expression.translate-cache.v1';
+const translateCacheStorageKey = 'meta-expression.translate-cache.v2';
 
 export function setupTranslatePage({
   cache = createPersistentWikimediaCache(translateCacheStorageKey),


### PR DESCRIPTION
Fixes #110

## Summary
- Add a browser-only `doublets-web` adapter that loads the WASM package, exposes the shared doublet value store, and round-trips portable meta-language cases.
- Persist browser meta-language cases and Wikimedia/translate cache entries as `doublets-web` binary blobs, with fallback reads from the previous v1 JSON cache keys.
- Include `doublets-web` JS/WASM assets in the GitHub Pages artifact and teach the static module graph verifier to validate `.wasm` resources.
- Add Playwright/browser smoke coverage for saving/loading portable links and cache-style binary decode through `doublets-web`.

## Reproduction and Verification
- Reproduced the missing browser store by adding `js/tests/e2e/issue-110.test.js`; before the implementation, the browser adapter import path did not exist.
- The smoke test now serves `/web/`, imports `../js/src/browser-doublets-web.js`, saves and loads portable meta-language links through `doublets-web`, and verifies cache-style decode from the default root index.

## Tests
- `node --test js/tests/integration/issue-63.test.js js/tests/e2e/issue-110.test.js js/tests/e2e/issue-116.test.js`
- `npm run check`
- `npm test`
- `bun test --timeout 30000`
- `npm run test:wasm`
- `GITHUB_BASE_REF=main bun scripts/validate-changeset.mjs`

No UI layout changed, so no screenshots are included.
