### PR TITLE
Add explicit interlingua reconstruction metadata

### DIFF
--- a/.changeset/issue-112-explicit-interlingua.md
+++ b/.changeset/issue-112-explicit-interlingua.md
@@ -1,0 +1,7 @@
+---
+'meta-expression': minor
+---
+
+Add explicit linguistic source reconstruction metadata and route translation
+and naturalization through the reconstructed semantic meta language instead of
+raw formalization text.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T21:57:25.542Z for PR creation at branch issue-112-c3cd1e55fea7 for issue https://github.com/link-assistant/meta-expression/issues/112

--- a/docs/case-studies/issue-112/README.md
+++ b/docs/case-studies/issue-112/README.md
@@ -1,0 +1,23 @@
+# Issue 112 - Explicit Interlingua Reconstruction
+
+Issue: <https://github.com/link-assistant/meta-expression/issues/112>
+
+## Summary
+
+The formalization stage now emits a `sourceReconstruction` surface model inside
+linguistic metadata. The model records ordered source units for tokens,
+separators, and symbols, plus sentence-to-unit links, so consumers can rebuild
+the source text without reading the raw `text` field.
+
+The linguistic metadata also records explicit noun/verb phrase attachments,
+subject-predicate agreement, token-level morphology, deterministic dependency
+coverage for grammar tokens such as determiners, and simple pronoun
+coreference chains.
+
+## Regression
+
+`js/tests/integration/issue-112-explicit-interlingua.test.js` poisons raw source
+string fields after formalization and verifies translation still produces
+`alpha beta -> альфа бета` from the reconstructed semantic meta language. The
+same test verifies naturalization reads the semantic reconstruction when its
+raw `text` field is poisoned.

--- a/docs/case-studies/issue-112/REQUIREMENTS.md
+++ b/docs/case-studies/issue-112/REQUIREMENTS.md
@@ -1,0 +1,9 @@
+# Requirements
+
+| Requirement                                                                        | Status | Evidence                                                                                                                                                                  |
+| ---------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reconstruct source text from formalization metadata without the raw source string. | Done   | `sourceReconstruction.units` and `sourceReconstruction.sentences` are emitted by `linguistic-metadata.js`; the issue-112 test rebuilds `Moon orbits the Sun.` from units. |
+| Make implicit linguistic relations explicit.                                       | Done   | Metadata now includes attachments, agreements, token features, determiner dependency coverage, and coreference chains.                                                    |
+| Ensure translation reads the semantic meta language after formalization.           | Done   | `translate.js` builds sentence segments from `semanticMetaLanguage.sourceReconstruction` instead of `formalization.text`.                                                 |
+| Ensure naturalization can read reconstructed semantic metadata.                    | Done   | `naturalize.js` derives semantic input text from `sourceReconstruction` before falling back to raw text.                                                                  |
+| Add a guard test that fails when translation reads raw source text.                | Done   | `issue-112-explicit-interlingua.test.js` poisons raw source fields and expects translation/naturalization to remain correct.                                              |

--- a/docs/case-studies/issue-112/SOLUTION-PLAN.md
+++ b/docs/case-studies/issue-112/SOLUTION-PLAN.md
@@ -1,0 +1,17 @@
+# Solution Plan
+
+1. Preserve the source surface as structured metadata:
+   `sourceReconstruction` stores token, separator, and symbol units with stable
+   ids and sentence membership.
+2. Enrich deterministic linguistic metadata:
+   tokens and word fragments carry morphology; sentence metadata records
+   attachments, agreement, dependency, and coreference records.
+3. Route translation through the interlingua:
+   `buildSemanticMetaLanguage()` copies the reconstruction into the semantic
+   layer and reconstructs the semantic source text from units.
+4. Route naturalization through the interlingua:
+   semantic-meta-language input uses `sourceReconstruction` before consulting a
+   raw text fallback.
+5. Lock the behavior with a poisoning regression:
+   the test mutates raw source string fields after formalization, proving the
+   post-formalization translation path is not using them.

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1235,6 +1235,9 @@ export interface LinguisticFragment {
   role: string;
   text: string;
   tokens: string[];
+  lemma: string | null;
+  partOfSpeech: string | null;
+  features: Record<string, unknown>;
   tokenStart: number | null;
   tokenEnd: number | null;
   sourceStart: number | null;
@@ -1250,6 +1253,7 @@ export interface LinguisticDependency {
   headFragmentId: string;
   dependentFragmentId: string;
   source: string;
+  granularity?: 'token' | 'fragment' | string;
   version: number;
   provenance: LinguisticProvenance;
 }
@@ -1282,12 +1286,46 @@ export interface LinguisticProvenance {
   layer: string;
 }
 
+export interface LinguisticSourceUnit {
+  id: string;
+  type: 'source-unit' | string;
+  version: number;
+  kind: 'token' | 'symbol' | 'separator' | string;
+  text: string;
+  tokenIndex?: number;
+  symbolId?: string;
+  sourceStart: number;
+  sourceEnd: number;
+  provenance: LinguisticProvenance;
+}
+
+export interface LinguisticSourceSentence {
+  id: string;
+  tokenStart: number;
+  tokenEnd: number;
+  sourceStart: number;
+  sourceEnd: number;
+  unitIds: string[];
+}
+
+export interface LinguisticSourceReconstruction {
+  type: 'source-reconstruction' | string;
+  version: number;
+  language: string;
+  units: LinguisticSourceUnit[];
+  sentences: LinguisticSourceSentence[];
+  provenance: LinguisticProvenance;
+}
+
 export interface LinguisticCstToken {
   type: 'token-cst' | string;
   id: string;
   version: number;
   text: string;
   index: number;
+  lemma: string | null;
+  partOfSpeech: string | null;
+  features: Record<string, unknown>;
   sourceStart: number | null;
   sourceEnd: number | null;
   sentenceBoundaryAfter: boolean;
@@ -1327,6 +1365,8 @@ export interface LinguisticCstSentence {
   objectFragmentId?: string | null;
   relationId?: string | null;
   dependencyIds?: string[];
+  attachmentIds?: string[];
+  agreementIds?: string[];
   provenance: LinguisticProvenance;
 }
 
@@ -1336,6 +1376,7 @@ export interface LinguisticCst {
   text: string;
   language: string;
   parser: LinguisticParserDescriptor;
+  sourceReconstruction: LinguisticSourceReconstruction;
   tokens: LinguisticCstToken[];
   symbols: LinguisticCstSymbol[];
   sentences: LinguisticCstSentence[];
@@ -1359,6 +1400,48 @@ export interface LinguisticAstNode {
   object?: Record<string, unknown> | null;
   relationId?: string | null;
   dependencyIds?: string[];
+  attachmentIds?: string[];
+  agreementIds?: string[];
+}
+
+export interface LinguisticAttachment {
+  id: string;
+  type: 'noun-phrase-attachment' | 'verb-phrase-attachment' | string;
+  fragmentId: string;
+  role: string;
+  tokenStart: number | null;
+  tokenEnd: number | null;
+  version: number;
+  provenance: LinguisticProvenance;
+}
+
+export interface LinguisticAgreement {
+  id: string;
+  type: 'subject-predicate-agreement' | string;
+  leftFragmentId: string;
+  rightFragmentId: string;
+  features: Record<string, unknown>;
+  version: number;
+  provenance: LinguisticProvenance;
+}
+
+export interface LinguisticCoreferenceMention {
+  fragmentId: string;
+  text: string;
+  role: string;
+  sourceStart: number | null;
+  sourceEnd: number | null;
+  features: Record<string, unknown>;
+}
+
+export interface LinguisticCoreferenceChain {
+  id: string;
+  type: 'coreference-chain' | string;
+  version: number;
+  antecedentFragmentId: string;
+  mentionFragmentIds: string[];
+  mentions: LinguisticCoreferenceMention[];
+  provenance: LinguisticProvenance;
 }
 
 export interface LinguisticMetadata {
@@ -1367,9 +1450,13 @@ export interface LinguisticMetadata {
   parser: LinguisticParserDescriptor;
   provenance: LinguisticProvenance;
   text: string;
+  sourceReconstruction: LinguisticSourceReconstruction;
   fragments: LinguisticFragment[];
   dependencies: LinguisticDependency[];
   relations: LinguisticRelation[];
+  attachments: LinguisticAttachment[];
+  agreements: LinguisticAgreement[];
+  coreferenceChains: LinguisticCoreferenceChain[];
   ast: LinguisticAstNode;
   cst: LinguisticCst;
 }
@@ -1797,6 +1884,14 @@ export declare function annotateLinguisticMetadataPhraseRefs<
   T extends { start: number; end: number; id: string },
 >(metadata: LinguisticMetadata, phrases: T[]): LinguisticMetadata;
 
+export declare function reconstructTextFromLinguisticMetadata(
+  metadata: LinguisticMetadata
+): string;
+
+export declare function reconstructTextFromSourceReconstruction(
+  sourceReconstruction: LinguisticSourceReconstruction
+): string | null;
+
 export interface TranslateOptions extends FormalizeOptions {
   sourceLanguage?: string;
   targetLanguage?: string;
@@ -2019,6 +2114,7 @@ export interface SemanticMetaLanguage {
   targetLanguage: string;
   representation: 'links-notation';
   sourceLinksNotation: string;
+  sourceReconstruction: LinguisticSourceReconstruction | null;
   links: SemanticMetaLanguageLink[];
   linksNotation: string;
 }

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -153,6 +153,8 @@ export {
 export {
   annotateLinguisticMetadataPhraseRefs,
   extractLinguisticMetadata,
+  reconstructTextFromLinguisticMetadata,
+  reconstructTextFromSourceReconstruction,
 } from './linguistic-metadata.js';
 export {
   buildOverrideMap,

--- a/js/src/linguistic-metadata.js
+++ b/js/src/linguistic-metadata.js
@@ -1,3 +1,10 @@
+import {
+  buildSourceReconstruction,
+  reconstructTextFromSourceReconstruction,
+} from './linguistic-reconstruction.js';
+
+export { reconstructTextFromSourceReconstruction } from './linguistic-reconstruction.js';
+
 const englishArticles = new Set(['a', 'an', 'the']);
 const englishConjunctions = new Set(['and', 'or', 'but']);
 const englishPrepositions = new Set([
@@ -87,6 +94,69 @@ const englishVerbLexemes = new Set([
   'writes',
   'wrote',
 ]);
+const englishPronouns = new Map([
+  ['i', { person: 1, number: 'singular' }],
+  ['me', { person: 1, number: 'singular' }],
+  ['we', { person: 1, number: 'plural' }],
+  ['us', { person: 1, number: 'plural' }],
+  ['you', { person: 2, number: 'unknown' }],
+  ['he', { person: 3, number: 'singular', gender: 'masculine' }],
+  ['him', { person: 3, number: 'singular', gender: 'masculine' }],
+  ['she', { person: 3, number: 'singular', gender: 'feminine' }],
+  ['her', { person: 3, number: 'singular', gender: 'feminine' }],
+  ['it', { person: 3, number: 'singular', gender: 'neuter' }],
+  ['they', { person: 3, number: 'plural' }],
+  ['them', { person: 3, number: 'plural' }],
+]);
+const englishPastVerbLexemes = new Set([
+  'was',
+  'were',
+  'had',
+  'created',
+  'discovered',
+  'invented',
+  'owned',
+  'related',
+  'translated',
+  'wrote',
+]);
+const englishVerbLemmas = new Map([
+  ['adds', 'add'],
+  ['applies', 'apply'],
+  ['belongs', 'belong'],
+  ['checks', 'check'],
+  ['compares', 'compare'],
+  ['contains', 'contain'],
+  ['created', 'create'],
+  ['creates', 'create'],
+  ['discovered', 'discover'],
+  ['discovers', 'discover'],
+  ['finds', 'find'],
+  ['formalizes', 'formalize'],
+  ['has', 'have'],
+  ['had', 'have'],
+  ['invented', 'invent'],
+  ['invents', 'invent'],
+  ['is', 'be'],
+  ['am', 'be'],
+  ['are', 'be'],
+  ['was', 'be'],
+  ['were', 'be'],
+  ['being', 'be'],
+  ['been', 'be'],
+  ['orbits', 'orbit'],
+  ['owned', 'own'],
+  ['owns', 'own'],
+  ['related', 'relate'],
+  ['relates', 'relate'],
+  ['runs', 'run'],
+  ['searches', 'search'],
+  ['supports', 'support'],
+  ['translated', 'translate'],
+  ['translates', 'translate'],
+  ['writes', 'write'],
+  ['wrote', 'write'],
+]);
 
 const linguisticParserId = 'meta-expression-linguistic-parser';
 const linguisticParserVersion = 1;
@@ -111,10 +181,17 @@ export function extractLinguisticMetadata(input, options = {}) {
     ...options,
     language,
   });
+  const sourceReconstruction = buildSourceReconstruction(
+    parse,
+    createLinguisticProvenance
+  );
   const fragments = [];
   const dependencies = [];
   const relations = [];
+  const attachments = [];
+  const agreements = [];
   const astSentences = [];
+  const wordFragmentIdsByToken = new Map();
 
   const addFragment = (fragment) => {
     const entry = {
@@ -123,6 +200,9 @@ export function extractLinguisticMetadata(input, options = {}) {
       role: fragment.role ?? fragment.type,
       text: fragment.text,
       tokens: fragment.tokens ?? [],
+      lemma: fragment.lemma ?? null,
+      partOfSpeech: fragment.partOfSpeech ?? null,
+      features: fragment.features ?? {},
       tokenStart: fragment.tokenStart ?? null,
       tokenEnd: fragment.tokenEnd ?? null,
       sourceStart: fragment.sourceStart ?? null,
@@ -138,16 +218,20 @@ export function extractLinguisticMetadata(input, options = {}) {
   };
 
   for (const token of parse.tokens) {
-    addFragment({
+    const fragment = addFragment({
       type: 'word',
       role: 'word',
       text: token.text,
       tokens: [token.text],
+      lemma: token.lemma,
+      partOfSpeech: token.partOfSpeech,
+      features: token.features,
       tokenStart: token.index,
       tokenEnd: token.index,
       sourceStart: token.sourceStart,
       sourceEnd: token.sourceEnd,
     });
+    wordFragmentIdsByToken.set(token.index, fragment.id);
   }
 
   for (const symbol of parse.symbols) {
@@ -155,6 +239,8 @@ export function extractLinguisticMetadata(input, options = {}) {
       type: 'symbol',
       role: 'symbol',
       text: symbol.text,
+      partOfSpeech: 'punctuation',
+      features: { punctuation: symbol.text },
       sourceStart: symbol.sourceStart,
       sourceEnd: symbol.sourceEnd,
     });
@@ -168,6 +254,9 @@ export function extractLinguisticMetadata(input, options = {}) {
       addFragment,
       dependencies,
       relations,
+      attachments,
+      agreements,
+      wordFragmentIdsByToken,
     });
     astSentences.push(sentenceMetadata);
   }
@@ -180,6 +269,7 @@ export function extractLinguisticMetadata(input, options = {}) {
     text,
     body: astSentences,
   };
+  const coreferenceChains = inferCoreferenceChains(fragments);
 
   return {
     version: 1,
@@ -187,12 +277,24 @@ export function extractLinguisticMetadata(input, options = {}) {
     parser: parse.parser,
     provenance: createLinguisticProvenance('metadata'),
     text,
+    sourceReconstruction,
     fragments,
     dependencies,
     relations,
+    attachments,
+    agreements,
+    coreferenceChains,
     ast,
-    cst: buildLinguisticCst(parse),
+    cst: buildLinguisticCst(parse, sourceReconstruction),
   };
+}
+
+export function reconstructTextFromLinguisticMetadata(metadata) {
+  return (
+    reconstructTextFromSourceReconstruction(
+      metadata?.sourceReconstruction ?? metadata?.cst?.sourceReconstruction
+    ) ?? String(metadata?.text ?? '')
+  );
 }
 
 /**
@@ -242,6 +344,10 @@ function parseLinguisticDocument(text, options) {
   const language = normalizeLanguage(options.language);
   const parser = createParserDescriptor(language);
   const tokenSpans = normalizeTokenSpans(options.tokenSpans, text);
+  const analyzedTokenSpans = tokenSpans.map((span) => ({
+    ...span,
+    analysis: analyzeToken(span.token, language),
+  }));
   const symbols = extractSymbolSpans(text).map((symbol, index) => ({
     type: 'symbol-cst',
     id: `symbol-${index + 1}`,
@@ -251,7 +357,8 @@ function parseLinguisticDocument(text, options) {
     sourceEnd: symbol.end,
     provenance: createLinguisticProvenance('cst-symbol'),
   }));
-  const tokens = tokenSpans.map((span, index) => ({
+  const tokens = analyzedTokenSpans.map((span, index) => ({
+    ...span.analysis,
     type: 'token-cst',
     id: `token-${index + 1}`,
     version: 1,
@@ -262,13 +369,14 @@ function parseLinguisticDocument(text, options) {
     sentenceBoundaryAfter: span.sentenceBoundaryAfter,
     provenance: createLinguisticProvenance('cst-token'),
   }));
-  const sentences = segmentSentences(tokenSpans, text).map((sentence, index) =>
-    parseLinguisticSentence({
-      text,
-      tokenSpans,
-      sentence,
-      sentenceIndex: index,
-    })
+  const sentences = segmentSentences(analyzedTokenSpans, text).map(
+    (sentence, index) =>
+      parseLinguisticSentence({
+        text,
+        tokenSpans: analyzedTokenSpans,
+        sentence,
+        sentenceIndex: index,
+      })
   );
 
   return {
@@ -277,7 +385,7 @@ function parseLinguisticDocument(text, options) {
     text,
     language,
     parser,
-    tokenSpans,
+    tokenSpans: analyzedTokenSpans,
     tokens,
     symbols,
     sentences,
@@ -386,13 +494,14 @@ function parseLinguisticSentence({
   };
 }
 
-function buildLinguisticCst(parse) {
+function buildLinguisticCst(parse, sourceReconstruction) {
   return {
     type: 'document-cst',
     version: 1,
     text: parse.text,
     language: parse.language,
     parser: parse.parser,
+    sourceReconstruction,
     tokens: parse.tokens,
     symbols: parse.symbols,
     sentences: parse.sentences,
@@ -426,8 +535,13 @@ function extractSentenceMetadata({
   addFragment,
   dependencies,
   relations,
+  attachments,
+  agreements,
+  wordFragmentIdsByToken,
 }) {
   const dependencyIds = [];
+  const attachmentIds = [];
+  const agreementIds = [];
   const { subject, predicate, object, relation } = extractSentenceComponents({
     text,
     tokenSpans,
@@ -435,7 +549,12 @@ function extractSentenceMetadata({
     addFragment,
     dependencies,
     relations,
+    attachments,
+    agreements,
     dependencyIds,
+    attachmentIds,
+    agreementIds,
+    wordFragmentIdsByToken,
   });
   Object.assign(parsedSentence, {
     subjectFragmentId: subject?.id ?? null,
@@ -443,6 +562,8 @@ function extractSentenceMetadata({
     objectFragmentId: object?.id ?? null,
     relationId: relation?.id ?? null,
     dependencyIds: [...dependencyIds],
+    attachmentIds: [...attachmentIds],
+    agreementIds: [...agreementIds],
   });
 
   return {
@@ -460,6 +581,8 @@ function extractSentenceMetadata({
     object: object ? fragmentReference(object) : null,
     relationId: relation?.id ?? null,
     dependencyIds,
+    attachmentIds,
+    agreementIds,
   };
 }
 
@@ -470,7 +593,12 @@ function extractSentenceComponents({
   addFragment,
   dependencies,
   relations,
+  attachments,
+  agreements,
   dependencyIds,
+  attachmentIds,
+  agreementIds,
+  wordFragmentIdsByToken,
 }) {
   if (parsedSentence.predicateToken === null) {
     addNominalSentenceFragment({
@@ -488,7 +616,12 @@ function extractSentenceComponents({
     addFragment,
     dependencies,
     relations,
+    attachments,
+    agreements,
     dependencyIds,
+    attachmentIds,
+    agreementIds,
+    wordFragmentIdsByToken,
   });
 }
 
@@ -522,7 +655,12 @@ function extractPredicateSentenceComponents({
   addFragment,
   dependencies,
   relations,
+  attachments,
+  agreements,
   dependencyIds,
+  attachmentIds,
+  agreementIds,
+  wordFragmentIdsByToken,
 }) {
   const subject = addSubjectFragment({
     text,
@@ -545,13 +683,53 @@ function extractPredicateSentenceComponents({
   });
   const relation = addPredicateDependenciesAndRelation({
     text,
+    tokenSpans,
+    parsedSentence,
     dependencies,
     relations,
     dependencyIds,
+    wordFragmentIdsByToken,
     subject,
     predicate,
     object,
   });
+  if (subject) {
+    attachmentIds.push(
+      addAttachment(attachments, 'noun-phrase-attachment', subject.id, {
+        role: 'subject',
+        tokenStart: subject.tokenStart,
+        tokenEnd: subject.tokenEnd,
+      })
+    );
+  }
+  if (predicate) {
+    attachmentIds.push(
+      addAttachment(attachments, 'verb-phrase-attachment', predicate.id, {
+        role: 'predicate',
+        tokenStart: predicate.tokenStart,
+        tokenEnd: predicate.tokenEnd,
+      })
+    );
+  }
+  if (object) {
+    attachmentIds.push(
+      addAttachment(attachments, 'noun-phrase-attachment', object.id, {
+        role: 'object',
+        tokenStart: object.tokenStart,
+        tokenEnd: object.tokenEnd,
+      })
+    );
+  }
+  if (subject && predicate) {
+    agreementIds.push(
+      addAgreement(
+        agreements,
+        'subject-predicate-agreement',
+        subject,
+        predicate
+      )
+    );
+  }
   return { subject, predicate, object, relation };
 }
 
@@ -637,9 +815,12 @@ function addObjectFragment({
 
 function addPredicateDependenciesAndRelation({
   text,
+  tokenSpans,
+  parsedSentence,
   dependencies,
   relations,
   dependencyIds,
+  wordFragmentIdsByToken,
   subject,
   predicate,
   object,
@@ -658,6 +839,14 @@ function addPredicateDependenciesAndRelation({
       addDependency(dependencies, 'obj', predicate.id, object.id)
     );
   }
+  dependencyIds.push(
+    ...addTokenDependencyCoverage({
+      tokenSpans,
+      parsedSentence,
+      dependencies,
+      wordFragmentIdsByToken,
+    })
+  );
   return addRelation({
     relations,
     text,
@@ -665,6 +854,92 @@ function addPredicateDependenciesAndRelation({
     predicate,
     object,
   });
+}
+
+function addTokenDependencyCoverage({
+  tokenSpans,
+  parsedSentence,
+  dependencies,
+  wordFragmentIdsByToken,
+}) {
+  const dependencyIds = [];
+  const predicateWordId = wordFragmentIdsByToken.get(
+    parsedSentence.predicateToken
+  );
+  if (!predicateWordId) {
+    return dependencyIds;
+  }
+  dependencyIds.push(
+    addDependency(dependencies, 'root', predicateWordId, predicateWordId, {
+      granularity: 'token',
+    })
+  );
+  dependencyIds.push(
+    ...addNominalTokenDependencies({
+      tokenSpans,
+      dependencies,
+      wordFragmentIdsByToken,
+      predicateWordId,
+      phraseRange: parsedSentence.subjectRange,
+      headRelation: 'nsubj',
+    })
+  );
+  dependencyIds.push(
+    ...addNominalTokenDependencies({
+      tokenSpans,
+      dependencies,
+      wordFragmentIdsByToken,
+      predicateWordId,
+      phraseRange: parsedSentence.objectPhraseRange,
+      semanticHeadRange: parsedSentence.objectRange,
+      headRelation: 'obj',
+    })
+  );
+  return dependencyIds;
+}
+
+function addNominalTokenDependencies({
+  tokenSpans,
+  dependencies,
+  wordFragmentIdsByToken,
+  predicateWordId,
+  phraseRange,
+  semanticHeadRange = phraseRange,
+  headRelation,
+}) {
+  if (!phraseRange || !semanticHeadRange) {
+    return [];
+  }
+  const dependencyIds = [];
+  const headIndex = headTokenIndexForRange(tokenSpans, semanticHeadRange);
+  const headWordId = wordFragmentIdsByToken.get(headIndex);
+  if (!headWordId) {
+    return dependencyIds;
+  }
+  dependencyIds.push(
+    addDependency(dependencies, headRelation, predicateWordId, headWordId, {
+      granularity: 'token',
+    })
+  );
+  for (let index = phraseRange.start; index <= phraseRange.end; index += 1) {
+    if (index === headIndex) {
+      continue;
+    }
+    const dependentWordId = wordFragmentIdsByToken.get(index);
+    if (!dependentWordId) {
+      continue;
+    }
+    dependencyIds.push(
+      addDependency(
+        dependencies,
+        tokenDependentRelation(tokenSpans[index]?.token),
+        headWordId,
+        dependentWordId,
+        { granularity: 'token' }
+      )
+    );
+  }
+  return dependencyIds;
 }
 
 function addTokenRangeFragment(
@@ -677,6 +952,8 @@ function addTokenRangeFragment(
 ) {
   const first = tokenSpans[range.start];
   const last = tokenSpans[range.end];
+  const head = tokenSpans[headTokenIndexForRange(tokenSpans, range)];
+  const analysis = head?.analysis ?? analyzeToken(head?.token, 'en');
   return addFragment({
     type,
     role,
@@ -684,6 +961,13 @@ function addTokenRangeFragment(
     tokens: tokenSpans
       .slice(range.start, range.end + 1)
       .map((span) => span.token),
+    lemma: analysis.lemma,
+    partOfSpeech: phrasePartOfSpeech(type, analysis.partOfSpeech),
+    features: {
+      ...analysis.features,
+      headToken: head?.token ?? null,
+      headTokenIndex: headTokenIndexForRange(tokenSpans, range),
+    },
     tokenStart: range.start,
     tokenEnd: range.end,
     sourceStart: first.start,
@@ -695,7 +979,8 @@ function addDependency(
   dependencies,
   relation,
   headFragmentId,
-  dependentFragmentId
+  dependentFragmentId,
+  details = {}
 ) {
   const entry = {
     id: `dependency-${dependencies.length + 1}`,
@@ -704,9 +989,43 @@ function addDependency(
     dependentFragmentId,
     source: linguisticParserId,
     version: 1,
+    ...details,
     provenance: createLinguisticProvenance(`dependency:${relation}`),
   };
   dependencies.push(entry);
+  return entry.id;
+}
+
+function addAttachment(attachments, type, fragmentId, details) {
+  const entry = {
+    id: `attachment-${attachments.length + 1}`,
+    type,
+    fragmentId,
+    version: 1,
+    ...details,
+    provenance: createLinguisticProvenance(`attachment:${type}`),
+  };
+  attachments.push(entry);
+  return entry.id;
+}
+
+function addAgreement(agreements, type, left, right) {
+  const entry = {
+    id: `agreement-${agreements.length + 1}`,
+    type,
+    leftFragmentId: left.id,
+    rightFragmentId: right.id,
+    features: {
+      number: agreementValue(left.features?.number, right.features?.number),
+      person: agreementValue(left.features?.person, right.features?.person),
+      tense: right.features?.tense ?? null,
+      aspect: right.features?.aspect ?? null,
+      mood: right.features?.mood ?? null,
+    },
+    version: 1,
+    provenance: createLinguisticProvenance(`agreement:${type}`),
+  };
+  agreements.push(entry);
   return entry.id;
 }
 
@@ -852,6 +1171,222 @@ function trimNominalRange(tokenSpans, start, end, options) {
     right -= 1;
   }
   return left <= right ? { start: left, end: right } : null;
+}
+
+function analyzeToken(token, language) {
+  const text = String(token ?? '');
+  const lowered = normalizeToken(text);
+  if (!text) {
+    return emptyTokenAnalysis();
+  }
+  if (/^\d+(?:[.,]\d+)?$/.test(text)) {
+    return numeralTokenAnalysis(lowered, language);
+  }
+  if (language !== 'en') {
+    return lexicalTokenAnalysis(lowered, language);
+  }
+  return analyzeEnglishToken(text, lowered, language);
+}
+
+function analyzeEnglishToken(text, lowered, language) {
+  if (englishPronouns.has(lowered)) {
+    return pronounTokenAnalysis(lowered, language);
+  }
+  if (englishArticles.has(lowered)) {
+    return determinerTokenAnalysis(lowered, language);
+  }
+  if (englishPrepositions.has(lowered)) {
+    return adpositionTokenAnalysis(lowered, language);
+  }
+  if (englishConjunctions.has(lowered)) {
+    return conjunctionTokenAnalysis(lowered, language);
+  }
+  if (isVerbCandidate(text)) {
+    return verbTokenAnalysis(lowered, language);
+  }
+  return nounTokenAnalysis(text, lowered, language);
+}
+
+function numeralTokenAnalysis(lemma, language) {
+  return {
+    lemma,
+    partOfSpeech: 'numeral',
+    features: { language, numberType: 'cardinal' },
+  };
+}
+
+function lexicalTokenAnalysis(lemma, language) {
+  return {
+    lemma,
+    partOfSpeech: 'lexical-token',
+    features: { language },
+  };
+}
+
+function pronounTokenAnalysis(lemma, language) {
+  return {
+    lemma,
+    partOfSpeech: 'pronoun',
+    features: {
+      language,
+      ...englishPronouns.get(lemma),
+      pronominal: true,
+    },
+  };
+}
+
+function determinerTokenAnalysis(lemma, language) {
+  return {
+    lemma,
+    partOfSpeech: 'determiner',
+    features: {
+      language,
+      definiteness: lemma === 'the' ? 'definite' : 'indefinite',
+    },
+  };
+}
+
+function adpositionTokenAnalysis(lemma, language) {
+  return {
+    lemma,
+    partOfSpeech: 'adposition',
+    features: { language, adpositionType: 'preposition' },
+  };
+}
+
+function conjunctionTokenAnalysis(lemma, language) {
+  return {
+    lemma,
+    partOfSpeech: 'conjunction',
+    features: { language, conjunctionType: 'coordinating' },
+  };
+}
+
+function verbTokenAnalysis(lemma, language) {
+  return {
+    lemma: englishVerbLemmas.get(lemma) ?? lemma.replace(/s$/, ''),
+    partOfSpeech: 'verb',
+    features: {
+      language,
+      tense: englishPastVerbLexemes.has(lemma) ? 'past' : 'present',
+      aspect: lemma.endsWith('ing') ? 'progressive' : 'simple',
+      mood: 'indicative',
+      person: lemma.endsWith('s') || lemma === 'is' ? 3 : null,
+      number:
+        lemma.endsWith('s') || lemma === 'is' || lemma === 'was'
+          ? 'singular'
+          : null,
+    },
+  };
+}
+
+function nounTokenAnalysis(text, lemma, language) {
+  return {
+    lemma,
+    partOfSpeech: /^[A-Z]/.test(text) ? 'proper-noun' : 'noun',
+    features: {
+      language,
+      number: lemma.endsWith('s') && lemma.length > 3 ? 'plural' : 'singular',
+    },
+  };
+}
+
+function emptyTokenAnalysis() {
+  return { lemma: null, partOfSpeech: null, features: {} };
+}
+
+function phrasePartOfSpeech(type, headPartOfSpeech) {
+  if (type === 'noun-phrase' || type === 'subject' || type === 'object') {
+    return 'noun-phrase';
+  }
+  if (type === 'verb-phrase' || type === 'predicate') {
+    return 'verb-phrase';
+  }
+  return headPartOfSpeech;
+}
+
+function headTokenIndexForRange(tokenSpans, range) {
+  for (let index = range.end; index >= range.start; index -= 1) {
+    if (!shouldTrimRight(tokenSpans[index]?.token)) {
+      return index;
+    }
+  }
+  return range.end;
+}
+
+function tokenDependentRelation(token) {
+  const lowered = normalizeToken(token);
+  if (englishArticles.has(lowered)) {
+    return 'det';
+  }
+  if (englishPrepositions.has(lowered)) {
+    return 'case';
+  }
+  if (englishConjunctions.has(lowered)) {
+    return 'cc';
+  }
+  return 'compound';
+}
+
+function agreementValue(left, right) {
+  if (left && right && left === right) {
+    return left;
+  }
+  return left ?? right ?? null;
+}
+
+function inferCoreferenceChains(fragments) {
+  const mentions = fragments
+    .filter(
+      (fragment) => fragment.role === 'subject' || fragment.role === 'object'
+    )
+    .sort((left, right) => left.sourceStart - right.sourceStart);
+  const chains = [];
+  const antecedents = [];
+  for (const mention of mentions) {
+    if (!mention.features?.pronominal) {
+      antecedents.push(mention);
+      continue;
+    }
+    const antecedent = [...antecedents]
+      .reverse()
+      .find((entry) => coreferenceCompatible(entry, mention));
+    if (!antecedent) {
+      continue;
+    }
+    chains.push({
+      id: `coreference-chain-${chains.length + 1}`,
+      type: 'coreference-chain',
+      version: 1,
+      antecedentFragmentId: antecedent.id,
+      mentionFragmentIds: [antecedent.id, mention.id],
+      mentions: [antecedent, mention].map(coreferenceMention),
+      provenance: createLinguisticProvenance('coreference'),
+    });
+  }
+  return chains;
+}
+
+function coreferenceCompatible(antecedent, mention) {
+  const mentionNumber = mention.features?.number;
+  const antecedentNumber = antecedent.features?.number;
+  return (
+    !mentionNumber ||
+    !antecedentNumber ||
+    mentionNumber === 'unknown' ||
+    antecedentNumber === mentionNumber
+  );
+}
+
+function coreferenceMention(fragment) {
+  return {
+    fragmentId: fragment.id,
+    text: fragment.text,
+    role: fragment.role,
+    sourceStart: fragment.sourceStart,
+    sourceEnd: fragment.sourceEnd,
+    features: fragment.features,
+  };
 }
 
 function shouldTrimLeft(token, options) {

--- a/js/src/linguistic-reconstruction.js
+++ b/js/src/linguistic-reconstruction.js
@@ -1,0 +1,87 @@
+export function buildSourceReconstruction(parse, createProvenance) {
+  const parts = [
+    ...parse.tokens.map((token) => ({
+      kind: 'token',
+      text: token.text,
+      tokenIndex: token.index,
+      sourceStart: token.sourceStart,
+      sourceEnd: token.sourceEnd,
+    })),
+    ...parse.symbols.map((symbol) => ({
+      kind: 'symbol',
+      text: symbol.text,
+      symbolId: symbol.id,
+      sourceStart: symbol.sourceStart,
+      sourceEnd: symbol.sourceEnd,
+    })),
+  ]
+    .filter(
+      (part) =>
+        Number.isInteger(part.sourceStart) && Number.isInteger(part.sourceEnd)
+    )
+    .sort(
+      (left, right) =>
+        left.sourceStart - right.sourceStart || left.sourceEnd - right.sourceEnd
+    );
+  const units = [];
+  let cursor = 0;
+  for (const part of parts) {
+    if (part.sourceStart > cursor) {
+      units.push({
+        kind: 'separator',
+        text: parse.text.slice(cursor, part.sourceStart),
+        sourceStart: cursor,
+        sourceEnd: part.sourceStart,
+      });
+    }
+    if (part.sourceStart >= cursor) {
+      units.push(part);
+      cursor = part.sourceEnd;
+    }
+  }
+  if (cursor < parse.text.length) {
+    units.push({
+      kind: 'separator',
+      text: parse.text.slice(cursor),
+      sourceStart: cursor,
+      sourceEnd: parse.text.length,
+    });
+  }
+  const numberedUnits = units.map((unit, index) => ({
+    id: `source-unit-${index + 1}`,
+    type: 'source-unit',
+    version: 1,
+    ...unit,
+    provenance: createProvenance(`source-unit:${unit.kind}`),
+  }));
+  return {
+    type: 'source-reconstruction',
+    version: 1,
+    language: parse.language,
+    units: numberedUnits,
+    sentences: parse.sentences.map((sentence) => ({
+      id: sentence.id,
+      tokenStart: sentence.tokenStart,
+      tokenEnd: sentence.tokenEnd,
+      sourceStart: sentence.sourceStart,
+      sourceEnd: sentence.sourceEnd,
+      unitIds: numberedUnits
+        .filter((unit) => unitInsideRange(unit, sentence))
+        .map((unit) => unit.id),
+    })),
+    provenance: createProvenance('source-reconstruction'),
+  };
+}
+
+export function reconstructTextFromSourceReconstruction(sourceReconstruction) {
+  if (!Array.isArray(sourceReconstruction?.units)) {
+    return null;
+  }
+  return sourceReconstruction.units.map((unit) => unit.text ?? '').join('');
+}
+
+function unitInsideRange(unit, range) {
+  return (
+    unit.sourceStart >= range.sourceStart && unit.sourceEnd <= range.sourceEnd
+  );
+}

--- a/js/src/naturalize.js
+++ b/js/src/naturalize.js
@@ -9,6 +9,7 @@ import {
   escapeMarkdown,
   renderNaturalizationLinksNotation,
 } from './translation-renderers.js';
+import { reconstructSourceText } from './translation-source-fragment.js';
 
 const linksNotationParser = new LinksNotationParser();
 const roleOrder = ['subject', 'predicate', 'object'];
@@ -236,10 +237,13 @@ function expressionFromNaturalization(naturalization) {
 
 function expressionFromSemanticMetaLanguage(semantic) {
   const sortedLinks = [...semantic.links].sort(compareBySourcePosition);
+  const sourceText =
+    reconstructSourceText(semantic.sourceReconstruction) ??
+    semantic.text ??
+    sortedLinks.map((link) => link.sourceText).join(' ');
   return {
     inputFormat: 'semantic-meta-language',
-    sourceText:
-      semantic.text ?? sortedLinks.map((link) => link.sourceText).join(' '),
+    sourceText,
     sourceLanguage: semantic.sourceLanguage,
     targetLanguage: semantic.targetLanguage,
     sourceExpression: semantic,

--- a/js/src/translate.js
+++ b/js/src/translate.js
@@ -15,7 +15,11 @@ import {
   applyTextTransformationRules,
   collectTranslationTransformationRules,
 } from './transformation-rules.js';
-import { buildSemanticSourceFragment } from './translation-source-fragment.js';
+import {
+  buildSemanticSourceFragment,
+  reconstructSourceText,
+  segmentSemanticMetaLanguageSource,
+} from './translation-source-fragment.js';
 import {
   escapeAttribute,
   escapeHtml,
@@ -103,7 +107,7 @@ export async function translateTextWith(input, options = {}) {
     }
   }
   const sentences = await applySentenceTextTransformationRules(
-    buildTranslatedSentences(formalization, phrases, config),
+    buildTranslatedSentences(semanticMetaLanguage, phrases, config),
     config.beforeNaturalizationRules,
     transformationContext(config, 'before-naturalization')
   );
@@ -152,7 +156,7 @@ export async function translateTextWith(input, options = {}) {
     config,
   });
   let result = {
-    text: formalization.text,
+    text: semanticMetaLanguage.text,
     sourceLanguage: config.sourceLanguage,
     targetLanguage: config.targetLanguage,
     formalization,
@@ -233,14 +237,19 @@ function buildSemanticMetaLanguage(formalization, config) {
   const links = formalization.cst.phrases.map((phrase, index) =>
     buildSemanticLink(phrase, index, config)
   );
+  const sourceReconstruction =
+    formalization.cst.linguisticMetadata?.sourceReconstruction ?? null;
+  const sourceText =
+    reconstructSourceText(sourceReconstruction) ?? formalization.text;
   const semantic = {
     type: 'semantic-meta-language',
     version: 1,
-    text: formalization.text,
+    text: sourceText,
     sourceLanguage: config.sourceLanguage,
     targetLanguage: config.targetLanguage,
     representation: 'links-notation',
     sourceLinksNotation: formalization.linksNotation,
+    sourceReconstruction,
     links,
   };
   return {
@@ -714,7 +723,7 @@ function buildTranslationCst({
   return {
     type: 'translation',
     version: 1,
-    text: formalization.text,
+    text: semanticMetaLanguage.text,
     sourceLanguage: config.sourceLanguage,
     targetLanguage: config.targetLanguage,
     formalization: formalization.cst,
@@ -740,34 +749,11 @@ function buildTranslationCst({
   };
 }
 
-function buildTranslatedSentences(formalization, phrases, config) {
-  const segments = segmentSourceText(formalization.text);
+function buildTranslatedSentences(semanticMetaLanguage, phrases, config) {
+  const segments = segmentSemanticMetaLanguageSource(semanticMetaLanguage);
   return segments.map((segment, index) =>
     buildTranslatedSentence(segment, index, phrases, config)
   );
-}
-
-function segmentSourceText(text) {
-  const source = String(text);
-  const segments = [];
-  const pattern = /\S[\s\S]*?(?:[.!?]+(?=\s|$)|$)/g;
-  for (const match of source.matchAll(pattern)) {
-    const raw = match[0];
-    const leading = raw.search(/\S/);
-    const start = (match.index ?? 0) + Math.max(leading, 0);
-    const trimmed = raw.trim();
-    if (!trimmed) {
-      continue;
-    }
-    segments.push({
-      text: trimmed,
-      start,
-      end: start + trimmed.length,
-    });
-  }
-  return segments.length
-    ? segments
-    : [{ text: source, start: 0, end: source.length }];
 }
 
 function buildTranslatedSentence(segment, index, phrases, config) {

--- a/js/src/translation-source-fragment.js
+++ b/js/src/translation-source-fragment.js
@@ -9,3 +9,74 @@ export function buildSemanticSourceFragment(phrase) {
     fragmentIds,
   };
 }
+
+export function reconstructSourceText(sourceReconstruction) {
+  if (!Array.isArray(sourceReconstruction?.units)) {
+    return null;
+  }
+  return sourceReconstruction.units.map((unit) => unit.text ?? '').join('');
+}
+
+export function segmentSemanticMetaLanguageSource(semantic) {
+  const reconstructed = segmentSourceReconstruction(
+    semantic?.sourceReconstruction
+  );
+  if (reconstructed.length > 0) {
+    return reconstructed;
+  }
+  return segmentSourceText(semantic?.text ?? '');
+}
+
+function segmentSourceReconstruction(sourceReconstruction) {
+  if (
+    !Array.isArray(sourceReconstruction?.units) ||
+    !Array.isArray(sourceReconstruction?.sentences)
+  ) {
+    return [];
+  }
+  const unitsById = new Map(
+    sourceReconstruction.units.map((unit) => [unit.id, unit])
+  );
+  return sourceReconstruction.sentences
+    .map((sentence) => {
+      const units = sentence.unitIds
+        .map((id) => unitsById.get(id))
+        .filter(Boolean);
+      const text = units
+        .map((unit) => unit.text ?? '')
+        .join('')
+        .trim();
+      if (!text) {
+        return null;
+      }
+      return {
+        text,
+        start: sentence.sourceStart,
+        end: sentence.sourceEnd,
+      };
+    })
+    .filter(Boolean);
+}
+
+function segmentSourceText(text) {
+  const source = String(text);
+  const segments = [];
+  const pattern = /\S[\s\S]*?(?:[.!?]+(?=\s|$)|$)/g;
+  for (const match of source.matchAll(pattern)) {
+    const raw = match[0];
+    const leading = raw.search(/\S/);
+    const start = (match.index ?? 0) + Math.max(leading, 0);
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      continue;
+    }
+    segments.push({
+      text: trimmed,
+      start,
+      end: start + trimmed.length,
+    });
+  }
+  return segments.length
+    ? segments
+    : [{ text: source, start: 0, end: source.length }];
+}

--- a/js/tests/integration/issue-112-explicit-interlingua.test.js
+++ b/js/tests/integration/issue-112-explicit-interlingua.test.js
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'test-anywhere';
+import {
+  formalizeTextWith,
+  naturalizeExpressionWith,
+  translateTextWith,
+} from '../../src/index.js';
+
+function wikidataCandidate(id, label) {
+  return {
+    id,
+    label,
+    description: `${label} test entity`,
+    kind: 'entity',
+    source: 'wikidata',
+    sourceUrl: `https://www.wikidata.org/wiki/${id}`,
+    matchText: label,
+  };
+}
+
+function alphaBetaSource() {
+  return {
+    name: 'test-wikidata-source',
+    async searchPhrase(text) {
+      if (text === 'alpha') {
+        return [wikidataCandidate('Q1', 'alpha')];
+      }
+      if (text === 'beta') {
+        return [wikidataCandidate('Q2', 'beta')];
+      }
+      return [];
+    },
+  };
+}
+
+function emptySource() {
+  return {
+    name: 'empty-test-source',
+    async searchPhrase() {
+      return [];
+    },
+  };
+}
+
+function targetEntityPayload(url) {
+  const ids = new URL(String(url)).searchParams.get('ids')?.split('|') ?? [];
+  const values = {
+    Q1: 'альфа',
+    Q2: 'бета',
+  };
+  return {
+    entities: Object.fromEntries(
+      ids.map((id) => [
+        id,
+        {
+          id,
+          labels: {
+            ru: {
+              value: values[id],
+            },
+          },
+          descriptions: {
+            ru: {
+              value: `${values[id]} test entity`,
+            },
+          },
+          sitelinks: {},
+        },
+      ])
+    ),
+  };
+}
+
+function fetchTargetEntities(url) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    async json() {
+      return targetEntityPayload(url);
+    },
+  });
+}
+
+function poisonRawSourceStrings(formalization) {
+  const poison = 'x';
+  const metadata = formalization.cst.linguisticMetadata;
+  return {
+    ...formalization,
+    text: poison,
+    ast: {
+      ...formalization.ast,
+      text: poison,
+    },
+    cst: {
+      ...formalization.cst,
+      text: poison,
+      linguisticMetadata: {
+        ...metadata,
+        text: poison,
+        ast: {
+          ...metadata.ast,
+          text: poison,
+        },
+        cst: {
+          ...metadata.cst,
+          text: poison,
+          sentences: metadata.cst.sentences.map((sentence) => ({
+            ...sentence,
+            text: poison,
+          })),
+        },
+      },
+    },
+  };
+}
+
+function reconstructSourceText(sourceReconstruction) {
+  return sourceReconstruction.units.map((unit) => unit.text).join('');
+}
+
+describe('issue 112 - explicit interlingua reconstruction', () => {
+  it('formalization records enough linguistic metadata to reconstruct the source without the raw source string', async () => {
+    const result = await formalizeTextWith('Moon orbits the Sun.', {
+      fetch: null,
+      sources: [emptySource()],
+      now: () => 0,
+    });
+    const metadata = result.cst.linguisticMetadata;
+
+    expect(reconstructSourceText(metadata.sourceReconstruction)).toBe(
+      'Moon orbits the Sun.'
+    );
+    expect(
+      metadata.sourceReconstruction.units.map((unit) => unit.kind)
+    ).toEqual([
+      'token',
+      'separator',
+      'token',
+      'separator',
+      'token',
+      'separator',
+      'token',
+      'symbol',
+    ]);
+    expect(metadata.attachments.map((entry) => entry.type)).toContain(
+      'noun-phrase-attachment'
+    );
+    expect(metadata.attachments.map((entry) => entry.type)).toContain(
+      'verb-phrase-attachment'
+    );
+    expect(metadata.agreements.map((entry) => entry.type)).toContain(
+      'subject-predicate-agreement'
+    );
+    expect(metadata.dependencies.map((entry) => entry.relation)).toContain(
+      'det'
+    );
+    expect(metadata.cst.tokens.every((token) => token.features)).toBe(true);
+  });
+
+  it('carries explicit coreference chains in the formalization metadata', async () => {
+    const result = await formalizeTextWith('Moon orbits the Sun. It shines.', {
+      fetch: null,
+      sources: [emptySource()],
+      now: () => 0,
+    });
+    const chain = result.cst.linguisticMetadata.coreferenceChains.find(
+      (entry) => entry.mentions.some((mention) => mention.text === 'It')
+    );
+
+    expect(Boolean(chain)).toBe(true);
+    expect(chain.mentions.map((mention) => mention.text)).toEqual([
+      'Sun',
+      'It',
+    ]);
+  });
+
+  it('translates and naturalizes from the reconstructed semantic meta language after raw source strings are poisoned', async () => {
+    const result = await translateTextWith('alpha beta', {
+      fetch: fetchTargetEntities,
+      sources: [alphaBetaSource()],
+      sourceLanguage: 'en',
+      targetLanguage: 'ru',
+      now: () => 0,
+      afterFormalizationRules: [poisonRawSourceStrings],
+    });
+
+    expect(result.text).toBe('alpha beta');
+    expect(result.sentences[0].source.text).toBe('alpha beta');
+    expect(result.plainText).toBe('альфа бета');
+    expect(result.semanticMetaLanguage.sourceReconstruction.units.length).toBe(
+      3
+    );
+
+    const naturalized = await naturalizeExpressionWith({
+      ...result.semanticMetaLanguage,
+      text: 'x',
+    });
+    expect(naturalized.text).toBe('alpha beta');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #112

- Add formalization-time `sourceReconstruction` metadata with ordered token, separator, symbol, and sentence-unit records.
- Enrich linguistic metadata with morphology, attachments, agreement, token dependency coverage, and deterministic coreference chains.
- Route translation and semantic-meta-language naturalization through reconstructed metadata before falling back to raw text.
- Add an issue-112 regression that poisons raw source strings after formalization and verifies translation and naturalization still use the reconstructed interlingua.

## Tests

- `node --test js/tests/integration/issue-112-explicit-interlingua.test.js`
- `npm run check`
- `npm test`
- `bash scripts/check-file-line-limits.sh`
- `bash scripts/check-mjs-syntax.sh`
- `npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
- `node scripts/check-version.mjs`

## Notes

The branch was merged with `origin/main`; git reported it was already up to date.